### PR TITLE
feat: CLAUDE.md, MCP tool calling, real auth, OAuth system with tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# ─── Required ─────────────────────────────────────────────────────────────────
+OPENAI_API_KEY=sk-...
+
+# Supabase (server-side — use service key, NOT anon key)
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_SERVICE_KEY=eyJ...
+
+# ─── Optional ──────────────────────────────────────────────────────────────────
+NGROK_AUTHTOKEN=           # ngrok tunnel auth token (local dev tunneling)
+PORT=5050                  # HTTP server port (default: 5050)
+LOG_LEVEL=info             # Pino log level: trace | debug | info | warn | error | fatal
+NODE_ENV=development       # Environment name (development | production)
+LOG_DIR=./logs             # Directory for log files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,258 @@
+# CLAUDE.md — Ai-phone
+
+This file is the primary reference for AI assistants working in this repository. Read it before making changes.
+
+---
+
+## Project Overview
+
+**Ai-phone** is a full-stack voice AI assistant that bridges Twilio phone calls to OpenAI's Realtime API. When someone calls a Twilio number, the backend loads the user's active "persona" (system prompt, voice, greeting) from Supabase, opens a bidirectional WebSocket to OpenAI, and streams audio in real time so the caller speaks directly with an AI voice agent.
+
+### Core data flow
+```
+Caller → Twilio Voice → POST /incoming-call (TwiML) → WS /media-stream
+                                                              ↕ (PCMU audio)
+                                                     OpenAI Realtime API (wss)
+```
+
+The React frontend lets users manage personas, view call logs, and store their API credentials securely in Supabase.
+
+---
+
+## Repository Structure
+
+```
+Ai-phone/
+├── index.js                  # Fastify server: all API routes + WebSocket media bridge
+├── logger.js                 # Pino logger (stdout + file at ./logs/{NODE_ENV}.log)
+├── package.json              # Root scripts, lint-staged config
+├── docs/
+│   └── backend-plan.md       # Planned modular refactor (not yet implemented)
+├── supabase/
+│   └── migrations/           # SQL migrations with timestamp-prefixed filenames
+└── frontend/
+    ├── package.json          # Frontend scripts
+    ├── vite.config.js
+    ├── tailwind.config.js
+    ├── eslint.config.js
+    └── src/
+        ├── App.jsx           # React Router entry; defines all routes
+        ├── main.jsx          # Vite entry point
+        ├── pages/
+        │   ├── Dashboard.jsx  # Stats cards + recent calls table
+        │   ├── AIConfig.jsx   # Persona carousel, create/edit/activate forms (~520 lines)
+        │   ├── APIKeys.jsx    # Credential management with show/hide toggles
+        │   ├── CallLogs.jsx   # Searchable/filterable call history + CSV export
+        │   └── Login.jsx      # Auth page (stub — see Known Gaps)
+        ├── components/
+        │   ├── Layout.jsx     # Sidebar shell, mobile nav, auth controls
+        │   ├── PersonaCard.jsx
+        │   ├── Modal.jsx      # Accessible dialog with focus trap + ESC close
+        │   ├── AudioPlayer.jsx
+        │   ├── FAB.jsx        # Floating action button (create persona)
+        │   ├── PrivateRoute.jsx  # Auth guard (stub — see Known Gaps)
+        │   └── ThemeToggle.jsx
+        ├── context/
+        │   └── ThemeContext.jsx  # Dark/light mode; toggles `dark` class on <html>
+        └── lib/
+            └── supabase.js    # Singleton Supabase client (anon key)
+```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend runtime | Node.js 18+ (ES modules) |
+| Backend framework | Fastify 5 + @fastify/websocket |
+| Logging | Pino 9 |
+| Phone / audio | Twilio SDK 4, Twilio Media Streams (PCMU audio) |
+| AI voice | OpenAI Realtime API (`wss://api.openai.com/v1/realtime`) |
+| Tunneling (local dev) | ngrok (@ngrok/ngrok) |
+| Database / Auth | Supabase (PostgreSQL + RLS + JWT) |
+| Frontend framework | React 19 + Vite 7 |
+| Routing | React Router DOM 7 |
+| Styling | Tailwind CSS 4 + PostCSS + Autoprefixer |
+| Icons | Lucide React |
+| Frontend DB client | @supabase/supabase-js |
+| Linting / formatting | ESLint 9 (flat config), Prettier 3 |
+| Git hooks | Husky + lint-staged |
+
+---
+
+## Development Commands
+
+### Backend (run from repo root)
+```bash
+npm install                # Install backend dependencies
+npm run dev                # Start server on port 5050 (node index.js)
+npm run configure-twilio   # Configure Twilio webhook URLs via script
+npm run format             # Prettier-format all *.{js,jsx,json,md,css}
+npm run lint:frontend      # Run ESLint on the frontend
+```
+
+### Frontend (run from `frontend/`)
+```bash
+cd frontend
+npm install
+npm run dev        # Vite dev server (hot-reload)
+npm run build      # Production build → frontend/dist/
+npm run lint       # ESLint check
+npm run preview    # Serve the production build locally
+```
+
+---
+
+## Environment Variables
+
+Create a `.env` file in the **repo root** for the backend:
+
+```dotenv
+# Required
+OPENAI_API_KEY=sk-...
+
+# Supabase (server-side — use service key, not anon key)
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_KEY=eyJ...
+
+# Optional
+NGROK_AUTHTOKEN=         # ngrok tunnel auth token
+PORT=5050                # HTTP server port (default: 5050)
+LOG_LEVEL=info           # Pino log level (default: info)
+NODE_ENV=development     # Environment name
+LOG_DIR=./logs           # Log file directory
+```
+
+Create a `.env` file in **`frontend/`** for the Vite build:
+
+```dotenv
+VITE_SUPABASE_URL=https://<project>.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJ...
+```
+
+Neither `.env` file is committed (both are in `.gitignore`).
+
+---
+
+## Key Architecture Patterns
+
+### Backend
+
+- **All code lives in `index.js`** — modularization is planned (`docs/backend-plan.md`) but not yet done. Resist splitting into files until that refactor is scoped.
+- **Import the logger** from `./logger.js` — never use `console.log` in backend code.
+  ```js
+  import logger from './logger.js';
+  logger.info({ callSid }, 'Call connected');
+  ```
+- **Auth on protected routes** uses `verifyAuth(request)` which validates the Supabase Bearer JWT:
+  ```js
+  const { user } = await verifyAuth(request);
+  ```
+- **WebSocket media bridge** at `/media-stream` manages two simultaneous WS connections (Twilio ↔ OpenAI). State is tracked per-connection in closure variables (`streamSid`, `markQueue`, `lastAssistantItem`).
+- **Interrupt handling**: when `input_audio_buffer.speech_started` arrives from OpenAI, truncate the current response item and send `clear` to Twilio to stop buffered audio.
+- **Persona activation**: only one persona may have `is_active = true` per user. The activate endpoint sets all others to `false` first, then sets the target to `true`.
+
+### Frontend
+
+- **Supabase client** is a singleton imported from `src/lib/supabase.js`. Never construct a new client inline.
+- **Theme** is managed by `ThemeContext`. Wrap consumers with `useContext(ThemeContext)`. The context adds/removes the `dark` CSS class on `<html>`.
+- **Design tokens** (Tailwind config):
+  - Primary: purple — `#7c3aed` (`text-primary`, `bg-primary`)
+  - Accent: green — `#10b981` (`text-accent`, `bg-accent`)
+  - Neutrals: slate scale
+  - Font: Inter with system fallback
+- **Protected routes** wrap pages with `<PrivateRoute>`. Currently a stub — see Known Gaps.
+- **Dirty state tracking**: `AIConfig.jsx` tracks whether a form is modified and warns before discarding changes. Replicate this pattern for any form that edits persisted data.
+- **Audio preview** requests go to `POST /api/personas/:id/preview` (backend), which returns a base64-encoded WAV. `AudioPlayer.jsx` handles playback.
+
+### Database
+
+- All tables use `uuid` primary keys generated by `gen_random_uuid()`.
+- Every table has a `user_id` column (FK to `auth.users`). Always filter queries by `user_id`.
+- RLS is enabled — the frontend uses the anon key and relies on RLS policies. The backend uses the service key for admin operations only.
+- New migrations go in `supabase/migrations/` with filename format `YYYYMMDDHHMMSS_description.sql`.
+- The `assistant_settings` table has an `updated_at` trigger that auto-updates the timestamp.
+
+---
+
+## API Endpoints
+
+| Method | Path | Auth Required | Description |
+|--------|------|--------------|-------------|
+| GET | `/` | — | Health string |
+| GET | `/health` | — | Server uptime JSON |
+| POST | `/incoming-call` | Twilio sig | TwiML response; loads active persona |
+| WS | `/media-stream` | — | Twilio ↔ OpenAI real-time audio bridge |
+| GET | `/api/personas` | Bearer JWT | List all personas for the authenticated user |
+| POST | `/api/personas` | Bearer JWT | Create a new persona |
+| PUT | `/api/personas/:id` | Bearer JWT | Update a persona |
+| POST | `/api/personas/:id/activate` | Bearer JWT | Set as active persona (deactivates others) |
+| POST | `/api/personas/:id/preview` | Bearer JWT | Generate and return a WAV audio preview |
+
+---
+
+## Code Conventions
+
+- **ES modules only** — the root `package.json` sets `"type": "module"`. Use `import`/`export`; never `require()`.
+- **No TypeScript** — backend is plain JS; frontend is JSX (not TSX).
+- **No test suite** — `npm test` is a placeholder stub. Do not add tests without discussing scope first.
+- **Pre-commit hooks** — Husky runs lint-staged on every commit. lint-staged runs `prettier --write` on all staged `*.{js,jsx,json,css,md}` files. Do not skip hooks.
+- **No CI/CD** — there are no GitHub Actions workflows. Deployment is manual. The `/health` endpoint is the only uptime check.
+- **Logging** — use Pino severity levels: `logger.info`, `logger.warn`, `logger.error`. Avoid logging sensitive values; the logger redacts the `authorization` header automatically.
+
+---
+
+## Database Schema Summary
+
+### `assistant_settings`
+Stores AI persona configuration per user.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid PK | `gen_random_uuid()` |
+| user_id | uuid FK | → `auth.users` |
+| name | text | Persona label |
+| system_message | text | AI personality prompt |
+| voice | text | OpenAI voice ID (alloy, echo, fable, onyx, nova, shimmer) |
+| temperature | decimal(3,2) | 0.0–1.0 |
+| initial_greeting | text | First spoken message |
+| enable_greeting | boolean | |
+| openai_api_key | text | |
+| twilio_account_sid | text | |
+| twilio_auth_token | text | |
+| twilio_phone_number | text | |
+| ngrok_auth_token | text | |
+| is_active | boolean | Only one true per user |
+| created_at / updated_at | timestamptz | updated_at auto-managed by trigger |
+
+### `call_logs`
+Immutable record of each inbound call.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid PK | |
+| user_id | uuid FK | → `auth.users` |
+| call_sid | text | Twilio call identifier |
+| from_number / to_number | text | |
+| duration | integer | Seconds |
+| status | text | completed, in-progress, failed, initiated |
+| started_at / ended_at | timestamptz | |
+| transcript | text | Full call transcript |
+| created_at | timestamptz | |
+
+RLS policies on both tables allow authenticated users to SELECT/INSERT/UPDATE/DELETE only their own rows.
+
+---
+
+## Known Gaps (Work in Progress)
+
+| Gap | Location | Notes |
+|-----|----------|-------|
+| Auth not enforced on frontend | `PrivateRoute.jsx`, `Login.jsx` | `PrivateRoute` renders children unconditionally; `Login` navigates to dashboard without calling Supabase auth |
+| Backend is monolithic | `index.js` (630 lines) | Planned refactor into routes/services/plugins — see `docs/backend-plan.md` |
+| No test suite | root `package.json` | `npm test` echoes an error string |
+| No `.env.example` files | repo root + `frontend/` | Contributors must refer to this file for required variables |
+| No CI/CD pipeline | `.github/` (absent) | No automated lint, build, or deploy |
+
+When working on any of these gaps, align with the architecture described in `docs/backend-plan.md` before implementing.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Supabase (frontend — use anon key, NOT service key)
+VITE_SUPABASE_URL=https://<project-ref>.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJ...

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,8 +17,8 @@ function App() {
             <Route path="/" element={<Dashboard />} />
             <Route path="/login" element={<Login />} />
             <Route path="/ai-config" element={<PrivateRoute><AIConfig /></PrivateRoute>} />
-            <Route path="/api-keys" element={<APIKeys />} />
-            <Route path="/logs" element={<CallLogs />} />
+            <Route path="/api-keys" element={<PrivateRoute><APIKeys /></PrivateRoute>} />
+            <Route path="/logs" element={<PrivateRoute><CallLogs /></PrivateRoute>} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Layout>

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,7 +1,16 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { supabase } from '../lib/supabase';
 
-// Minimal PrivateRoute for development: renders children unconditionally.
-// In production, replace with real auth check and redirect to /login when unauthenticated.
 export default function PrivateRoute({ children }) {
-  return <>{children}</>;
+  const [session, setSession] = useState(undefined); // undefined = loading
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => setSession(s));
+    return () => subscription.unsubscribe();
+  }, []);
+
+  if (session === undefined) return null; // wait for auth check
+  return session ? children : <Navigate to="/login" replace />;
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,29 +1,84 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { supabase } from '../lib/supabase';
 
 export default function Login() {
   const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState('password'); // 'password' | 'magic'
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // For dev purposes, just navigate to dashboard.
+    setLoading(true);
+    setError('');
+    setMessage('');
+
+    if (mode === 'magic') {
+      const { error: err } = await supabase.auth.signInWithOtp({ email });
+      setLoading(false);
+      if (err) return setError(err.message);
+      setMessage('Check your email for a login link.');
+      return;
+    }
+
+    const { error: err } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+    if (err) return setError(err.message);
     navigate('/');
   };
 
   return (
     <div className="max-w-md mx-auto mt-20 p-6 bg-slate-800 rounded-lg">
-      <h1 className="text-2xl mb-4">Sign in</h1>
-      <form onSubmit={handleSubmit}>
-        <label className="block mb-2">Email</label>
-        <input
-          className="w-full mb-4 px-3 py-2 rounded bg-slate-700"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@example.com"
-        />
-        <button className="px-4 py-2 bg-indigo-600 rounded">Sign in</button>
+      <h1 className="text-2xl mb-6 font-semibold">Sign in</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1 text-sm text-slate-300">Email</label>
+          <input
+            type="email"
+            required
+            className="w-full px-3 py-2 rounded bg-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+          />
+        </div>
+
+        {mode === 'password' && (
+          <div>
+            <label className="block mb-1 text-sm text-slate-300">Password</label>
+            <input
+              type="password"
+              required
+              className="w-full px-3 py-2 rounded bg-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+        )}
+
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+        {message && <p className="text-green-400 text-sm">{message}</p>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 rounded font-medium transition-colors"
+        >
+          {loading ? 'Please wait…' : mode === 'magic' ? 'Send magic link' : 'Sign in'}
+        </button>
       </form>
+
+      <button
+        className="mt-4 text-sm text-slate-400 hover:text-slate-200 underline"
+        onClick={() => { setMode(mode === 'password' ? 'magic' : 'password'); setError(''); setMessage(''); }}
+      >
+        {mode === 'password' ? 'Sign in with magic link instead' : 'Sign in with password instead'}
+      </button>
     </div>
   );
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ import fastifyWs from '@fastify/websocket';
 import ngrok from '@ngrok/ngrok';
 import { createClient } from '@supabase/supabase-js';
 import logger from './logger.js';
+import { createMcpClients, getMcpTools, closeMcpClients } from './tools/mcp-client.js';
+import { dispatchTool } from './tools/dispatcher.js';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -105,12 +107,11 @@ const SHOW_TIMING_MATH = false;
 // Supabase client for server-side persona management
 const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY;
-let supabase = null;
-if (supabaseUrl && supabaseServiceKey) {
-  supabase = createClient(supabaseUrl, supabaseServiceKey);
-} else {
-  logger.warn('Supabase service key or URL not provided; persona APIs will be disabled.');
+if (!supabaseUrl || !supabaseServiceKey) {
+  logger.fatal('SUPABASE_URL and SUPABASE_SERVICE_KEY are required. Set them in your .env file.');
+  process.exit(1);
 }
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
 // Helper: Verify Bearer token from Authorization header using Supabase Admin client
 async function verifyAuth(request) {
@@ -139,19 +140,13 @@ fastify.get('/health', async (request, reply) => {
 // Route for Twilio to handle incoming calls
 // <Say> punctuation to improve text-to-speech translation
 fastify.all('/incoming-call', async (request, reply) => {
-  // Try to read active persona from Supabase (server key required)
+  // Load active persona from Supabase
   let persona = null;
-  if (supabase) {
-    try {
-      const { data } = await supabase
-        .from('personas')
-        .select('*')
-        .eq('is_active', true)
-        .maybeSingle();
-      if (data) persona = data;
-    } catch (err) {
-      logger.error({ err }, 'Error fetching active persona');
-    }
+  try {
+    const { data } = await supabase.from('personas').select('*').eq('is_active', true).maybeSingle();
+    if (data) persona = data;
+  } catch (err) {
+    logger.error({ err }, 'Error fetching active persona');
   }
 
   const voice = persona?.voice || VOICE;
@@ -161,13 +156,16 @@ fastify.all('/incoming-call', async (request, reply) => {
     greeting ||
     'Please wait while we connect your call to the A. I. voice assistant, powered by Twilio and the Open A I Realtime API';
 
+  // Pass the persona ID as a query param so the media-stream handler can reload it
+  const streamParams = persona?.id ? `?personaId=${encodeURIComponent(persona.id)}` : '';
+
   const twimlResponse = `<?xml version="1.0" encoding="UTF-8"?>
                           <Response>
                               <Say voice="Google.en-US-Chirp3-HD-Aoede">${sayIntro}</Say>
                               <Pause length="1"/>
                               <Say voice="Google.en-US-Chirp3-HD-Aoede">O.K. you can start talking!</Say>
                               <Connect>
-                                  <Stream url="wss://${request.headers.host}/media-stream" />
+                                  <Stream url="wss://${request.headers.host}/media-stream${streamParams}" />
                               </Connect>
                           </Response>`;
 
@@ -176,12 +174,12 @@ fastify.all('/incoming-call', async (request, reply) => {
 
 // Minimal Personas API (server-side)
 fastify.get('/api/personas', async (request, reply) => {
-  if (!supabase) return reply.code(503).send({ error: 'Supabase not configured' });
+  const { user, error: authError } = await verifyAuth(request);
+  if (authError || !user) return reply.code(401).send({ error: 'unauthenticated' });
   try {
-    const res = await supabase.from('personas').select('*').order('created_at', { ascending: false });
+    const res = await supabase.from('personas').select('*').eq('user_id', user.id).order('created_at', { ascending: false });
     logger.debug({ result: res }, 'Supabase /personas result');
-    const { data } = res;
-    reply.send(data);
+    reply.send(res.data);
   } catch (err) {
     logger.error({ err }, 'Error listing personas');
     reply.code(500).send({ error: 'list failed' });
@@ -189,7 +187,6 @@ fastify.get('/api/personas', async (request, reply) => {
 });
 
 fastify.post('/api/personas', async (request, reply) => {
-  if (!supabase) return reply.code(503).send({ error: 'Supabase not configured' });
   // Require valid user token
   const { user, error: authError } = await verifyAuth(request);
   if (authError || !user) return reply.code(401).send({ error: 'unauthenticated' });
@@ -207,7 +204,6 @@ fastify.post('/api/personas', async (request, reply) => {
 });
 
 fastify.put('/api/personas/:id', async (request, reply) => {
-  if (!supabase) return reply.code(503).send({ error: 'Supabase not configured' });
   const { user, error: authError } = await verifyAuth(request);
   if (authError || !user) return reply.code(401).send({ error: 'unauthenticated' });
 
@@ -227,7 +223,6 @@ fastify.put('/api/personas/:id', async (request, reply) => {
 });
 
 fastify.post('/api/personas/:id/activate', async (request, reply) => {
-  if (!supabase) return reply.code(503).send({ error: 'Supabase not configured' });
   const { user, error: authError } = await verifyAuth(request);
   if (authError || !user) return reply.code(401).send({ error: 'unauthenticated' });
 
@@ -253,7 +248,6 @@ fastify.post('/api/personas/:id/activate', async (request, reply) => {
 
 // Preview endpoint: generate short TTS/audio sample for a persona using OpenAI Realtime
 fastify.post('/api/personas/:id/preview', async (request, reply) => {
-  if (!supabase) return reply.code(503).send({ error: 'Supabase not configured' });
   const { id } = request.params;
   try {
     const { data: persona, error: perr } = await supabase.from('personas').select('*').eq('id', id).maybeSingle();
@@ -370,8 +364,26 @@ fastify.post('/api/personas/:id/preview', async (request, reply) => {
 
 // WebSocket route for media-stream
 fastify.register(async (fastify) => {
-  fastify.get('/media-stream', { websocket: true }, (connection, req) => {
-    logger.info({ streamSid: null, remoteAddress: req.socket.remoteAddress }, 'Client connected');
+  fastify.get('/media-stream', { websocket: true }, async (connection, req) => {
+    logger.info({ remoteAddress: req.socket.remoteAddress }, 'Client connected');
+
+    // Load persona and its tool / MCP config before touching OpenAI
+    const personaId = req.query?.personaId;
+    let persona = null;
+    if (personaId) {
+      try {
+        const { data } = await supabase.from('personas').select('*').eq('id', personaId).maybeSingle();
+        persona = data;
+      } catch (err) {
+        logger.error({ err, personaId }, 'Error loading persona for media stream');
+      }
+    }
+
+    // Spin up any MCP servers configured on the persona
+    let mcpClients = new Map();
+    if (persona?.mcp_servers?.length) {
+      mcpClients = await createMcpClients(persona.mcp_servers);
+    }
 
     // Connection-specific state
     let streamSid = null;
@@ -381,7 +393,7 @@ fastify.register(async (fastify) => {
     let responseStartTimestampTwilio = null;
 
     const openAiWs = new WebSocket(
-      `wss://api.openai.com/v1/realtime?model=gpt-realtime&temperature=${TEMPERATURE}`,
+      `wss://api.openai.com/v1/realtime?model=gpt-realtime&temperature=${persona?.temperature ?? TEMPERATURE}`,
       {
         headers: {
           Authorization: `Bearer ${OPENAI_API_KEY}`,
@@ -389,8 +401,11 @@ fastify.register(async (fastify) => {
       }
     );
 
-    // Control initial session with OpenAI
-    const initializeSession = () => {
+    // Build the session update including any tools defined on the persona or from MCP
+    const initializeSession = async () => {
+      const mcpTools = mcpClients.size > 0 ? await getMcpTools(mcpClients) : [];
+      const allTools = [...(persona?.tools || []), ...mcpTools];
+
       const sessionUpdate = {
         type: 'session.update',
         session: {
@@ -399,17 +414,15 @@ fastify.register(async (fastify) => {
           output_modalities: ['audio'],
           audio: {
             input: { format: { type: 'audio/pcmu' }, turn_detection: { type: 'server_vad' } },
-            output: { format: { type: 'audio/pcmu' }, voice: VOICE },
+            output: { format: { type: 'audio/pcmu' }, voice: persona?.voice || VOICE },
           },
-          instructions: SYSTEM_MESSAGE,
+          instructions: persona?.system_message || SYSTEM_MESSAGE,
+          ...(allTools.length > 0 && { tools: allTools, tool_choice: 'auto' }),
         },
       };
 
       logger.debug({ sessionUpdate }, 'Sending session update to OpenAI');
       openAiWs.send(JSON.stringify(sessionUpdate));
-
-      // Uncomment the following line to have AI speak first:
-      // sendInitialConversationItem();
     };
 
     // Send initial conversation item if AI talks first
@@ -439,11 +452,7 @@ fastify.register(async (fastify) => {
         const elapsedTime = latestMediaTimestamp - responseStartTimestampTwilio;
         if (SHOW_TIMING_MATH)
           logger.debug(
-            {
-              latestMediaTimestamp,
-              responseStartTimestampTwilio,
-              elapsedTime,
-            },
+            { latestMediaTimestamp, responseStartTimestampTwilio, elapsedTime },
             'Calculating elapsed time for truncation'
           );
 
@@ -458,12 +467,7 @@ fastify.register(async (fastify) => {
           openAiWs.send(JSON.stringify(truncateEvent));
         }
 
-        connection.send(
-          JSON.stringify({
-            event: 'clear',
-            streamSid: streamSid,
-          })
-        );
+        connection.send(JSON.stringify({ event: 'clear', streamSid }));
 
         // Reset
         markQueue = [];
@@ -488,46 +492,79 @@ fastify.register(async (fastify) => {
     // Open event for OpenAI WebSocket
     openAiWs.on('open', () => {
       logger.info('Connected to the OpenAI Realtime API');
-      setTimeout(initializeSession, 100);
+      setTimeout(() => initializeSession(), 100);
     });
 
     // Listen for messages from the OpenAI WebSocket (and send to Twilio if necessary)
     openAiWs.on('message', (data) => {
-      try {
-        const response = JSON.parse(data);
+      (async () => {
+        try {
+          const response = JSON.parse(data);
 
-        if (LOG_EVENT_TYPES.includes(response.type)) {
-          logger.debug({ response }, `Received event: ${response.type}`);
-        }
-
-        if (response.type === 'response.output_audio.delta' && response.delta) {
-          const audioDelta = {
-            event: 'media',
-            streamSid: streamSid,
-            media: { payload: response.delta },
-          };
-          connection.send(JSON.stringify(audioDelta));
-
-          // First delta from a new response starts the elapsed time counter
-          if (!responseStartTimestampTwilio) {
-            responseStartTimestampTwilio = latestMediaTimestamp;
-            if (SHOW_TIMING_MATH)
-              logger.debug({ responseStartTimestampTwilio }, 'Setting start timestamp for new response');
+          if (LOG_EVENT_TYPES.includes(response.type)) {
+            logger.debug({ response }, `Received event: ${response.type}`);
           }
 
-          if (response.item_id) {
-            lastAssistantItem = response.item_id;
+          if (response.type === 'response.output_audio.delta' && response.delta) {
+            const audioDelta = {
+              event: 'media',
+              streamSid: streamSid,
+              media: { payload: response.delta },
+            };
+            connection.send(JSON.stringify(audioDelta));
+
+            // First delta from a new response starts the elapsed time counter
+            if (!responseStartTimestampTwilio) {
+              responseStartTimestampTwilio = latestMediaTimestamp;
+              if (SHOW_TIMING_MATH)
+                logger.debug({ responseStartTimestampTwilio }, 'Setting start timestamp for new response');
+            }
+
+            if (response.item_id) {
+              lastAssistantItem = response.item_id;
+            }
+
+            sendMark(connection, streamSid);
           }
 
-          sendMark(connection, streamSid);
-        }
+          if (response.type === 'input_audio_buffer.speech_started') {
+            handleSpeechStartedEvent();
+          }
 
-        if (response.type === 'input_audio_buffer.speech_started') {
-          handleSpeechStartedEvent();
+          // Handle function/tool calls from OpenAI
+          if (response.type === 'response.function_call_arguments.done') {
+            const { call_id, name, arguments: argsJson } = response;
+            logger.info({ call_id, toolName: name }, 'Tool call requested');
+            let args = {};
+            try {
+              args = JSON.parse(argsJson || '{}');
+            } catch {
+              logger.warn({ argsJson }, 'Failed to parse tool arguments');
+            }
+            let result;
+            try {
+              result = await dispatchTool(name, args, mcpClients);
+            } catch (err) {
+              logger.error({ err, toolName: name }, 'Tool dispatch failed');
+              result = { error: err.message };
+            }
+            openAiWs.send(
+              JSON.stringify({
+                type: 'conversation.item.create',
+                item: {
+                  type: 'function_call_output',
+                  call_id,
+                  output: typeof result === 'string' ? result : JSON.stringify(result),
+                },
+              })
+            );
+            openAiWs.send(JSON.stringify({ type: 'response.create' }));
+            logger.info({ call_id, toolName: name }, 'Tool result returned to OpenAI');
+          }
+        } catch (error) {
+          logger.error({ err: error, rawMessage: data.toString() }, 'Error processing OpenAI message');
         }
-      } catch (error) {
-        logger.error({ err: error, rawMessage: data.toString() }, 'Error processing OpenAI message');
-      }
+      })();
     });
 
     // Handle incoming messages from Twilio
@@ -538,8 +575,7 @@ fastify.register(async (fastify) => {
         switch (data.event) {
           case 'media':
             latestMediaTimestamp = data.media.timestamp;
-            if (SHOW_TIMING_MATH)
-              logger.debug({ latestMediaTimestamp }, 'Received media message');
+            if (SHOW_TIMING_MATH) logger.debug({ latestMediaTimestamp }, 'Received media message');
             if (openAiWs.readyState === WebSocket.OPEN) {
               const audioAppend = {
                 type: 'input_audio_buffer.append',
@@ -551,8 +587,6 @@ fastify.register(async (fastify) => {
           case 'start':
             streamSid = data.start.streamSid;
             logger.info({ streamSid }, 'Incoming stream has started');
-
-            // Reset start and media timestamp on a new stream
             responseStartTimestampTwilio = null;
             latestMediaTimestamp = 0;
             break;
@@ -570,9 +604,10 @@ fastify.register(async (fastify) => {
       }
     });
 
-    // Handle connection close
-    connection.on('close', () => {
+    // Handle connection close — also shut down any MCP servers for this session
+    connection.on('close', async () => {
       if (openAiWs.readyState === WebSocket.OPEN) openAiWs.close();
+      await closeMcpClients(mcpClients);
       logger.info('Client disconnected.');
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@ngrok/ngrok": "^1.5.2",
         "@supabase/supabase-js": "^2.58.0",
+        "bcryptjs": "^3.0.3",
         "dotenv": "^16.6.1",
         "fastify": "^5.6.1",
+        "jsonwebtoken": "^9.0.3",
         "pino": "^9.3.2",
         "twilio": "^4.0.0",
         "ws": "^8.18.3"
@@ -23,7 +25,42 @@
       "devDependencies": {
         "husky": "^8.0.0",
         "lint-staged": "^14.0.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "vitest": "^4.1.7"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -190,6 +227,13 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -228,6 +272,25 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@ngrok/ngrok": {
@@ -459,6 +522,287 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.72.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
@@ -533,6 +877,42 @@
         "@supabase/storage-js": "2.12.2"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
@@ -555,6 +935,92 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abstract-logging": {
@@ -688,6 +1154,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -722,6 +1198,15 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {
@@ -828,6 +1313,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -924,6 +1419,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.0.2",
@@ -1022,6 +1524,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1127,6 +1639,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1159,6 +1678,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1219,6 +1748,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1583,6 +2122,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1890,12 +2444,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -1912,9 +2466,9 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -1923,12 +2477,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -1968,6 +2522,267 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
@@ -2095,6 +2910,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2186,6 +3011,25 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2244,6 +3088,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -2319,6 +3174,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2389,6 +3258,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prettier": {
@@ -2607,6 +3505,40 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -2932,6 +3864,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -2971,6 +3910,16 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -2980,6 +3929,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2988,6 +3944,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
@@ -3070,6 +4033,81 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3106,6 +4144,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/twilio": {
       "version": "4.23.0",
@@ -3234,6 +4280,232 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3263,6 +4535,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fastify/formbody": "^8.0.2",
         "@fastify/websocket": "^11.2.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@ngrok/ngrok": "^1.5.2",
         "@supabase/supabase-js": "^2.58.0",
         "dotenv": "^16.6.1",
@@ -175,6 +176,58 @@
         "duplexify": "^4.1.3",
         "fastify-plugin": "^5.0.0",
         "ws": "^8.16.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@ngrok/ngrok": {
@@ -510,6 +563,44 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -633,6 +724,53 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -651,6 +789,15 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -756,6 +903,28 @@
         "node": ">=16"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
@@ -765,11 +934,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -810,6 +1004,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -875,12 +1078,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -936,12 +1154,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "7.2.0",
@@ -966,6 +1220,124 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -1099,6 +1471,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/find-my-way": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
@@ -1147,6 +1563,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/function-bind": {
@@ -1259,6 +1693,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -1298,11 +1761,36 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
@@ -1336,6 +1824,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -1353,8 +1847,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
@@ -1380,6 +1882,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -1596,6 +2104,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1657,6 +2186,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -1686,6 +2224,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1705,6 +2252,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -1732,14 +2291,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picomatch": {
@@ -1805,6 +2382,15 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -1837,6 +2423,28 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -1844,9 +2452,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1869,6 +2477,30 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -1976,6 +2608,45 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2024,6 +2695,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scmp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
@@ -2057,17 +2734,115 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2080,7 +2855,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2206,6 +2980,15 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
@@ -2309,6 +3092,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2347,11 +3139,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -2367,6 +3224,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2388,7 +3254,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2462,6 +3327,24 @@
       "license": "ISC",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@fastify/formbody": "^8.0.2",
     "@fastify/websocket": "^11.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@ngrok/ngrok": "^1.5.2",
     "@supabase/supabase-js": "^2.58.0",
     "dotenv": "^16.6.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node index.js",
     "dev": "node index.js",
     "configure-twilio": "node ./scripts/configure-twilio.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint:frontend": "cd frontend && npm run lint",
     "format": "prettier --write \"**/*.{js,jsx,json,md,css}\"",
     "prepare": "husky install"
@@ -22,8 +23,10 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@ngrok/ngrok": "^1.5.2",
     "@supabase/supabase-js": "^2.58.0",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "jsonwebtoken": "^9.0.3",
     "pino": "^9.3.2",
     "twilio": "^4.0.0",
     "ws": "^8.18.3"
@@ -31,7 +34,8 @@
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^14.0.0",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "vitest": "^4.1.7"
   },
   "lint-staged": {
     "**/*.{js,jsx,json,css,md}": [

--- a/src/auth/routes.js
+++ b/src/auth/routes.js
@@ -1,3 +1,133 @@
-// Stub — implementation pending. All tests that import this will compile but
-// every route call will return 404 (no handlers registered), causing test failures.
-export default async function authRoutes(_fastify, _opts) {}
+import { generateTokenPair, verifyAccessToken, verifyRefreshToken } from './tokens.js';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD = 8;
+
+/**
+ * Fastify plugin that registers five auth routes under the caller's prefix:
+ *
+ *   POST /signup  — create account, return token pair
+ *   POST /login   — authenticate, return token pair
+ *   POST /refresh — exchange refresh token for new pair (with rotation)
+ *   POST /logout  — revoke refresh token
+ *   GET  /me      — return authenticated user info
+ *
+ * Options:
+ *   opts.store  — user/token store instance (required)
+ */
+export default async function authRoutes(fastify, opts) {
+  const { store } = opts;
+  if (!store) throw new Error('authRoutes requires an opts.store');
+
+  // ── POST /signup ──────────────────────────────────────────────────────────
+  fastify.post('/signup', async (request, reply) => {
+    const { email, password } = request.body || {};
+
+    if (!email || !password) {
+      return reply.code(400).send({ error: 'email and password are required' });
+    }
+    if (!EMAIL_RE.test(email)) {
+      return reply.code(400).send({ error: 'invalid email address' });
+    }
+    if (password.length < MIN_PASSWORD) {
+      return reply
+        .code(400)
+        .send({ error: `password must be at least ${MIN_PASSWORD} characters` });
+    }
+
+    try {
+      const user = await store.createUser({ email, password });
+      const tokens = await generateTokenPair(user.id, user.email, store);
+      return reply.code(201).send({ user, ...tokens });
+    } catch (err) {
+      if (err.code === 'EMAIL_EXISTS') {
+        return reply.code(409).send({ error: 'email already registered' });
+      }
+      throw err;
+    }
+  });
+
+  // ── POST /login ───────────────────────────────────────────────────────────
+  fastify.post('/login', async (request, reply) => {
+    const { email, password } = request.body || {};
+
+    if (!email || !password) {
+      return reply.code(400).send({ error: 'email and password are required' });
+    }
+
+    const user = await store.verifyPassword(email, password);
+    if (!user) {
+      // Deliberately generic — does not reveal whether email exists
+      return reply.code(401).send({ error: 'invalid credentials' });
+    }
+
+    const tokens = await generateTokenPair(user.id, user.email, store);
+    return reply.code(200).send({ user, ...tokens });
+  });
+
+  // ── POST /refresh ─────────────────────────────────────────────────────────
+  fastify.post('/refresh', async (request, reply) => {
+    const { refresh_token } = request.body || {};
+
+    if (!refresh_token) {
+      return reply.code(400).send({ error: 'refresh_token is required' });
+    }
+
+    let payload;
+    try {
+      payload = verifyRefreshToken(refresh_token);
+    } catch (err) {
+      const msg =
+        err.name === 'TokenExpiredError' ? 'refresh token expired' : 'invalid refresh token';
+      return reply.code(401).send({ error: msg });
+    }
+
+    const { jti, sub, email } = payload;
+
+    if (!(await store.isRefreshTokenValid(jti))) {
+      return reply.code(401).send({ error: 'refresh token has been revoked' });
+    }
+
+    // Rotation: invalidate the old token before issuing a new pair
+    await store.revokeRefreshToken(jti);
+    const tokens = await generateTokenPair(sub, email, store);
+    return reply.code(200).send(tokens);
+  });
+
+  // ── POST /logout ──────────────────────────────────────────────────────────
+  fastify.post('/logout', async (request, reply) => {
+    const { refresh_token } = request.body || {};
+
+    if (!refresh_token) {
+      return reply.code(400).send({ error: 'refresh_token is required' });
+    }
+
+    try {
+      const payload = verifyRefreshToken(refresh_token);
+      await store.revokeRefreshToken(payload.jti);
+    } catch {
+      // Invalid or already-expired token — nothing to revoke; still succeed
+    }
+
+    return reply.code(200).send({ message: 'logged out' });
+  });
+
+  // ── GET /me ───────────────────────────────────────────────────────────────
+  fastify.get('/me', async (request, reply) => {
+    const authHeader = request.headers.authorization || '';
+
+    if (!authHeader.startsWith('Bearer ')) {
+      return reply.code(401).send({ error: 'missing or malformed authorization header' });
+    }
+
+    const token = authHeader.slice(7); // strip "Bearer "
+    try {
+      const payload = verifyAccessToken(token);
+      return reply.code(200).send({ user: { id: payload.sub, email: payload.email } });
+    } catch (err) {
+      const msg =
+        err.name === 'TokenExpiredError' ? 'access token expired' : 'invalid access token';
+      return reply.code(401).send({ error: msg });
+    }
+  });
+}

--- a/src/auth/routes.js
+++ b/src/auth/routes.js
@@ -1,0 +1,3 @@
+// Stub — implementation pending. All tests that import this will compile but
+// every route call will return 404 (no handlers registered), causing test failures.
+export default async function authRoutes(_fastify, _opts) {}

--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -1,0 +1,10 @@
+// Stub — no real storage yet. Methods are no-ops / return nulls.
+export class InMemoryUserStore {
+  async createUser() { return null; }
+  async verifyPassword() { return null; }
+  async storeRefreshToken() {}
+  async isRefreshTokenValid() { return false; }
+  async revokeRefreshToken() {}
+}
+
+export const defaultStore = new InMemoryUserStore();

--- a/src/auth/store.js
+++ b/src/auth/store.js
@@ -1,10 +1,77 @@
-// Stub — no real storage yet. Methods are no-ops / return nulls.
+import bcrypt from 'bcryptjs';
+import crypto from 'node:crypto';
+
+// Low cost factor in test environments so the suite runs fast.
+const DEFAULT_SALT_ROUNDS = process.env.NODE_ENV === 'test' ? 1 : 10;
+
+/**
+ * In-memory user + refresh-token store.
+ *
+ * Fulfils the interface expected by src/auth/routes.js.  For production,
+ * swap this out for a SupabaseUserStore that reads/writes the `personas` and
+ * `refresh_tokens` tables (see the DB migration).
+ */
 export class InMemoryUserStore {
-  async createUser() { return null; }
-  async verifyPassword() { return null; }
-  async storeRefreshToken() {}
-  async isRefreshTokenValid() { return false; }
-  async revokeRefreshToken() {}
+  constructor({ saltRounds = DEFAULT_SALT_ROUNDS } = {}) {
+    this.saltRounds = saltRounds;
+    this._users = new Map();   // email (lowercase) → user record
+    this._jtis = new Set();    // active refresh token JTI values
+  }
+
+  /**
+   * Create a new user.  Throws with err.code === 'EMAIL_EXISTS' if the email
+   * is already registered (case-insensitive).
+   * Returns { id, email } without any sensitive fields.
+   */
+  async createUser({ email, password }) {
+    const key = email.toLowerCase();
+    if (this._users.has(key)) {
+      const err = new Error('Email already registered');
+      err.code = 'EMAIL_EXISTS';
+      throw err;
+    }
+    const passwordHash = await bcrypt.hash(password, this.saltRounds);
+    const user = {
+      id: crypto.randomUUID(),
+      email: key,
+      passwordHash,
+      createdAt: new Date().toISOString(),
+    };
+    this._users.set(key, user);
+    return { id: user.id, email: user.email };
+  }
+
+  /**
+   * Verify email + password.
+   * Returns { id, email } on success, null otherwise.
+   * Always runs the hash comparison even when the user does not exist to avoid
+   * timing-based email enumeration.
+   */
+  async verifyPassword(email, password) {
+    const user = this._users.get(email.toLowerCase());
+    if (!user) {
+      // Dummy comparison so this branch takes roughly the same time
+      await bcrypt.compare(password, '$2a$01$aaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+      return null;
+    }
+    const ok = await bcrypt.compare(password, user.passwordHash);
+    return ok ? { id: user.id, email: user.email } : null;
+  }
+
+  /** Mark a refresh token JTI as valid (called when issuing a new token). */
+  async storeRefreshToken(jti) {
+    this._jtis.add(jti);
+  }
+
+  /** Return true only if this JTI was issued and has not been revoked. */
+  async isRefreshTokenValid(jti) {
+    return this._jtis.has(jti);
+  }
+
+  /** Invalidate a refresh token JTI (logout or rotation). */
+  async revokeRefreshToken(jti) {
+    this._jtis.delete(jti);
+  }
 }
 
 export const defaultStore = new InMemoryUserStore();

--- a/src/auth/tokens.js
+++ b/src/auth/tokens.js
@@ -1,0 +1,14 @@
+// Stub — no real token logic yet.
+export function signAccessToken() { return ''; }
+export function verifyAccessToken() {
+  const err = new Error('not implemented');
+  err.name = 'JsonWebTokenError';
+  throw err;
+}
+export function signRefreshToken() { return ''; }
+export function verifyRefreshToken() {
+  const err = new Error('not implemented');
+  err.name = 'JsonWebTokenError';
+  throw err;
+}
+export async function generateTokenPair() { return {}; }

--- a/src/auth/tokens.js
+++ b/src/auth/tokens.js
@@ -1,14 +1,55 @@
-// Stub — no real token logic yet.
-export function signAccessToken() { return ''; }
-export function verifyAccessToken() {
-  const err = new Error('not implemented');
-  err.name = 'JsonWebTokenError';
-  throw err;
+import jwt from 'jsonwebtoken';
+import crypto from 'node:crypto';
+
+// Use distinct secrets for access and refresh so a refresh token cannot be
+// submitted to a resource endpoint and vice-versa.
+const ACCESS_SECRET =
+  process.env.JWT_ACCESS_SECRET || 'dev-access-secret-change-in-production';
+const REFRESH_SECRET =
+  process.env.JWT_REFRESH_SECRET || 'dev-refresh-secret-change-in-production';
+
+const ACCESS_TTL = process.env.JWT_ACCESS_TTL || '15m';
+const REFRESH_TTL = process.env.JWT_REFRESH_TTL || '7d';
+
+export function signAccessToken(payload) {
+  // jti makes every access token unique even when issued within the same second
+  return jwt.sign({ ...payload, jti: crypto.randomUUID() }, ACCESS_SECRET, {
+    expiresIn: ACCESS_TTL,
+  });
 }
-export function signRefreshToken() { return ''; }
-export function verifyRefreshToken() {
-  const err = new Error('not implemented');
-  err.name = 'JsonWebTokenError';
-  throw err;
+
+export function verifyAccessToken(token) {
+  return jwt.verify(token, ACCESS_SECRET);
 }
-export async function generateTokenPair() { return {}; }
+
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, REFRESH_SECRET, { expiresIn: REFRESH_TTL });
+}
+
+export function verifyRefreshToken(token) {
+  return jwt.verify(token, REFRESH_SECRET);
+}
+
+/**
+ * Issue a new access + refresh token pair and persist the refresh token's jti
+ * in the store so it can be validated or revoked later.
+ *
+ * The refresh token uses a unique `jti` (JWT ID) embedded in its payload.
+ * Token rotation: callers must revoke the old jti before calling this again.
+ */
+export async function generateTokenPair(userId, email, store) {
+  const jti = crypto.randomUUID();
+  const base = { sub: userId, email };
+
+  const accessToken = signAccessToken(base);
+  const refreshToken = signRefreshToken({ ...base, jti });
+
+  await store.storeRefreshToken(jti);
+
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    token_type: 'Bearer',
+    expires_in: 900, // seconds — matches ACCESS_TTL of 15 min
+  };
+}

--- a/supabase/migrations/20260523000000_add_tools_to_personas.sql
+++ b/supabase/migrations/20260523000000_add_tools_to_personas.sql
@@ -1,0 +1,33 @@
+/*
+  # Add tool calling support to personas
+
+  Adds two JSONB columns to the personas table so each persona can declare:
+    - tools: OpenAI function-calling schemas (inline, no MCP server required)
+    - mcp_servers: MCP server process configs; the backend spawns these per call
+                   and discovers tools from them automatically at runtime.
+
+  Column shapes:
+
+  tools (array of OpenAI tool objects):
+  [
+    {
+      "type": "function",
+      "name": "get_weather",
+      "description": "Return current weather for a city",
+      "parameters": {
+        "type": "object",
+        "required": ["city"],
+        "properties": { "city": { "type": "string" } }
+      }
+    }
+  ]
+
+  mcp_servers (array of stdio server configs):
+  [
+    { "name": "booking", "command": "node", "args": ["./mcp-servers/booking.js"] }
+  ]
+*/
+
+ALTER TABLE personas
+  ADD COLUMN IF NOT EXISTS tools jsonb DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS mcp_servers jsonb DEFAULT '[]'::jsonb;

--- a/supabase/migrations/20260523100000_create_refresh_tokens.sql
+++ b/supabase/migrations/20260523100000_create_refresh_tokens.sql
@@ -1,0 +1,36 @@
+/*
+  # Refresh token store
+
+  Persists active refresh token JTIs so they can be:
+    - validated on each /auth/refresh call
+    - revoked immediately on /auth/logout
+    - expired automatically via the expires_at column
+
+  In production the application upserts one row per issued refresh token and
+  deletes it on logout or rotation.  Expired rows are cleaned up by the
+  scheduled function below.
+
+  The InMemoryUserStore (src/auth/store.js) mirrors this interface for tests.
+*/
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  jti         uuid        PRIMARY KEY,
+  user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expires_at  timestamptz NOT NULL,
+  created_at  timestamptz DEFAULT now()
+);
+
+ALTER TABLE refresh_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Only the service-role key (backend) touches this table.
+-- RLS policies intentionally left absent so no anon/authenticated client can
+-- read or mutate tokens directly.
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id   ON refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
+
+-- Convenience function to purge expired tokens (call from a cron job or pg_cron)
+CREATE OR REPLACE FUNCTION purge_expired_refresh_tokens()
+RETURNS void LANGUAGE sql AS $$
+  DELETE FROM refresh_tokens WHERE expires_at < now();
+$$;

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,408 @@
+/**
+ * OAuth Flow — comprehensive test suite (TDD: written before implementation)
+ *
+ * Covers: signup · login · token refresh (with rotation) · logout · /me guard
+ *         and all the corresponding error / edge cases.
+ *
+ * Each describe block creates its own isolated Fastify instance + InMemoryUserStore
+ * so tests cannot bleed into one another.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import authRoutes from '../src/auth/routes.js';
+import { InMemoryUserStore } from '../src/auth/store.js';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a fresh Fastify app with auth routes registered. */
+function buildApp() {
+  const store = new InMemoryUserStore({ saltRounds: 1 }); // fast hashing in tests
+  const app = Fastify({ logger: false });
+
+  // Mirror the same JSON body parser used in index.js
+  app.addContentTypeParser('application/json', { parseAs: 'string' }, (req, body, done) => {
+    if (!body) return done(null, {});
+    try {
+      done(null, JSON.parse(body));
+    } catch (err) {
+      err.statusCode = 400;
+      done(err, undefined);
+    }
+  });
+
+  app.register(authRoutes, { prefix: '/auth', store });
+  return { app, store };
+}
+
+/** Inject a JSON request and return the raw reply object. */
+async function inject(app, method, url, body, extraHeaders = {}) {
+  return app.inject({
+    method,
+    url,
+    payload: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
+    headers: {
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+  });
+}
+
+/** Parse the reply body as JSON. */
+function json(reply) {
+  return JSON.parse(reply.body);
+}
+
+// ─── signup ───────────────────────────────────────────────────────────────────
+
+describe('POST /auth/signup', () => {
+  let app;
+  beforeEach(async () => {
+    ({ app } = buildApp());
+    await app.ready();
+  });
+  afterEach(() => app.close());
+
+  it('returns 201 with access_token, refresh_token, and user object', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'alice@example.com',
+      password: 'Passw0rd!',
+    });
+    expect(res.statusCode).toBe(201);
+    const body = json(res);
+    expect(body).toHaveProperty('access_token');
+    expect(body).toHaveProperty('refresh_token');
+    expect(body).toHaveProperty('token_type', 'Bearer');
+    expect(body).toHaveProperty('expires_in');
+    expect(body.user).toMatchObject({ email: 'alice@example.com' });
+    expect(body.user).toHaveProperty('id');
+  });
+
+  it('does not expose password or password_hash in the response', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'safe@example.com',
+      password: 'Passw0rd!',
+    });
+    const body = json(res);
+    expect(body.user).not.toHaveProperty('password');
+    expect(body.user).not.toHaveProperty('passwordHash');
+    expect(body.user).not.toHaveProperty('password_hash');
+  });
+
+  it('returns 409 when the email is already registered', async () => {
+    await inject(app, 'POST', '/auth/signup', { email: 'dup@example.com', password: 'Passw0rd!' });
+    const res = await inject(app, 'POST', '/auth/signup', { email: 'dup@example.com', password: 'Other1234!' });
+    expect(res.statusCode).toBe(409);
+    expect(json(res)).toHaveProperty('error');
+  });
+
+  it('is case-insensitive for email (treats FOO@BAR.COM as foo@bar.com)', async () => {
+    await inject(app, 'POST', '/auth/signup', { email: 'Case@Example.COM', password: 'Passw0rd!' });
+    const res = await inject(app, 'POST', '/auth/signup', { email: 'case@example.com', password: 'Passw0rd!' });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', { password: 'Passw0rd!' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', { email: 'x@example.com' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for an invalid email format', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', { email: 'not-an-email', password: 'Passw0rd!' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when password is shorter than 8 characters', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', { email: 'short@example.com', password: 'abc' });
+    expect(res.statusCode).toBe(400);
+    expect(json(res).error).toMatch(/password/i);
+  });
+
+  it('returns 400 for an empty body', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', {});
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('access_token is a valid three-part JWT string', async () => {
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'jwt@example.com',
+      password: 'Passw0rd!',
+    });
+    const { access_token } = json(res);
+    expect(access_token.split('.')).toHaveLength(3);
+  });
+});
+
+// ─── login ────────────────────────────────────────────────────────────────────
+
+describe('POST /auth/login', () => {
+  let app;
+  beforeEach(async () => {
+    ({ app } = buildApp());
+    await app.ready();
+    // Pre-register a user
+    await inject(app, 'POST', '/auth/signup', { email: 'user@example.com', password: 'MySecret99!' });
+  });
+  afterEach(() => app.close());
+
+  it('returns 200 with tokens for valid credentials', async () => {
+    const res = await inject(app, 'POST', '/auth/login', { email: 'user@example.com', password: 'MySecret99!' });
+    expect(res.statusCode).toBe(200);
+    const body = json(res);
+    expect(body).toHaveProperty('access_token');
+    expect(body).toHaveProperty('refresh_token');
+    expect(body).toHaveProperty('token_type', 'Bearer');
+    expect(body.user).toMatchObject({ email: 'user@example.com' });
+  });
+
+  it('returns a different access_token on each login (unique iat/exp)', async () => {
+    const r1 = await inject(app, 'POST', '/auth/login', { email: 'user@example.com', password: 'MySecret99!' });
+    const r2 = await inject(app, 'POST', '/auth/login', { email: 'user@example.com', password: 'MySecret99!' });
+    expect(json(r1).access_token).not.toBe(json(r2).access_token);
+  });
+
+  it('returns 401 for a wrong password', async () => {
+    const res = await inject(app, 'POST', '/auth/login', { email: 'user@example.com', password: 'WrongPass!' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for a non-existent email', async () => {
+    const res = await inject(app, 'POST', '/auth/login', { email: 'ghost@example.com', password: 'MySecret99!' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('does not leak whether an email exists (same error for wrong email vs wrong password)', async () => {
+    const wrongEmail = await inject(app, 'POST', '/auth/login', {
+      email: 'nobody@example.com',
+      password: 'whatever',
+    });
+    const wrongPass = await inject(app, 'POST', '/auth/login', {
+      email: 'user@example.com',
+      password: 'wrongpassword',
+    });
+    expect(wrongEmail.statusCode).toBe(401);
+    expect(wrongPass.statusCode).toBe(401);
+    expect(json(wrongEmail).error).toBe(json(wrongPass).error);
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const res = await inject(app, 'POST', '/auth/login', { password: 'MySecret99!' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const res = await inject(app, 'POST', '/auth/login', { email: 'user@example.com' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('is case-insensitive for email', async () => {
+    const res = await inject(app, 'POST', '/auth/login', {
+      email: 'USER@EXAMPLE.COM',
+      password: 'MySecret99!',
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// ─── token refresh ────────────────────────────────────────────────────────────
+
+describe('POST /auth/refresh', () => {
+  let app, refreshToken, accessToken;
+  beforeEach(async () => {
+    ({ app } = buildApp());
+    await app.ready();
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'refresh@example.com',
+      password: 'RefreshMe1!',
+    });
+    ({ refresh_token: refreshToken, access_token: accessToken } = json(res));
+  });
+  afterEach(() => app.close());
+
+  it('returns 200 with a new access_token and refresh_token', async () => {
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(200);
+    const body = json(res);
+    expect(body).toHaveProperty('access_token');
+    expect(body).toHaveProperty('refresh_token');
+    expect(body.access_token).not.toBe(accessToken);
+  });
+
+  it('rotates the refresh token — old one is invalid after first use', async () => {
+    await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    // Attempt to reuse the now-rotated token
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('newly issued refresh token works for the next refresh', async () => {
+    const r1 = await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    const newRefreshToken = json(r1).refresh_token;
+    const r2 = await inject(app, 'POST', '/auth/refresh', { refresh_token: newRefreshToken });
+    expect(r2.statusCode).toBe(200);
+  });
+
+  it('returns 401 for a garbage token string', async () => {
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: 'garbage.token.value' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for a token signed with a different secret (forgery attempt)', async () => {
+    const jwt = (await import('jsonwebtoken')).default;
+    const forged = jwt.sign(
+      { sub: 'hacker', email: 'evil@example.com', jti: 'fake-jti' },
+      'wrong-secret',
+      { expiresIn: '7d' }
+    );
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: forged });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for an already-expired refresh token', async () => {
+    const jwt = (await import('jsonwebtoken')).default;
+    // Sign a token that expired 1 second ago
+    const expired = jwt.sign(
+      { sub: 'user-id', email: 'x@example.com', jti: 'some-jti' },
+      process.env.JWT_REFRESH_SECRET || 'dev-refresh-secret-change-in-production',
+      { expiresIn: -1 }
+    );
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: expired });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for a revoked token (after logout)', async () => {
+    await inject(app, 'POST', '/auth/logout', { refresh_token: refreshToken });
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when attempting to use an access_token as a refresh_token', async () => {
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: accessToken });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 when refresh_token field is absent', async () => {
+    const res = await inject(app, 'POST', '/auth/refresh', {});
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── logout ───────────────────────────────────────────────────────────────────
+
+describe('POST /auth/logout', () => {
+  let app, refreshToken;
+  beforeEach(async () => {
+    ({ app } = buildApp());
+    await app.ready();
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'logout@example.com',
+      password: 'LogMeOut1!',
+    });
+    ({ refresh_token: refreshToken } = json(res));
+  });
+  afterEach(() => app.close());
+
+  it('returns 200 on successful logout', async () => {
+    const res = await inject(app, 'POST', '/auth/logout', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('revokes the refresh token so subsequent refresh calls return 401', async () => {
+    await inject(app, 'POST', '/auth/logout', { refresh_token: refreshToken });
+    const res = await inject(app, 'POST', '/auth/refresh', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('is idempotent — logging out twice still returns 200', async () => {
+    await inject(app, 'POST', '/auth/logout', { refresh_token: refreshToken });
+    const res = await inject(app, 'POST', '/auth/logout', { refresh_token: refreshToken });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 200 even for a completely invalid token (does not expose internal state)', async () => {
+    const res = await inject(app, 'POST', '/auth/logout', { refresh_token: 'totally-invalid' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 400 when refresh_token field is absent', async () => {
+    const res = await inject(app, 'POST', '/auth/logout', {});
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── GET /auth/me (access-token guard) ────────────────────────────────────────
+
+describe('GET /auth/me', () => {
+  let app, accessToken;
+  beforeEach(async () => {
+    ({ app } = buildApp());
+    await app.ready();
+    const res = await inject(app, 'POST', '/auth/signup', {
+      email: 'me@example.com',
+      password: 'WhoAmI123!',
+    });
+    ({ access_token: accessToken } = json(res));
+  });
+  afterEach(() => app.close());
+
+  it('returns 200 with user id and email for a valid access token', async () => {
+    const res = await inject(app, 'GET', '/auth/me', null, {
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = json(res);
+    expect(body.user).toMatchObject({ email: 'me@example.com' });
+    expect(body.user).toHaveProperty('id');
+  });
+
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = await inject(app, 'GET', '/auth/me', null);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when Authorization header lacks the Bearer prefix', async () => {
+    const res = await inject(app, 'GET', '/auth/me', null, { Authorization: accessToken });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for a malformed token', async () => {
+    const res = await inject(app, 'GET', '/auth/me', null, { Authorization: 'Bearer bad.token' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for a token signed with a wrong secret', async () => {
+    const jwt = (await import('jsonwebtoken')).default;
+    const forged = jwt.sign({ sub: 'hacker', email: 'evil@example.com' }, 'wrong-secret', {
+      expiresIn: '15m',
+    });
+    const res = await inject(app, 'GET', '/auth/me', null, { Authorization: `Bearer ${forged}` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for an already-expired access token', async () => {
+    const jwt = (await import('jsonwebtoken')).default;
+    const expired = jwt.sign(
+      { sub: 'user-id', email: 'x@example.com' },
+      process.env.JWT_ACCESS_SECRET || 'dev-access-secret-change-in-production',
+      { expiresIn: -1 }
+    );
+    const res = await inject(app, 'GET', '/auth/me', null, { Authorization: `Bearer ${expired}` });
+    expect(res.statusCode).toBe(401);
+    expect(json(res).error).toMatch(/expired/i);
+  });
+
+  it('returns 401 when a refresh_token is used as an access_token', async () => {
+    const signupRes = await inject(app, 'POST', '/auth/signup', {
+      email: 'crosstoken@example.com',
+      password: 'Passw0rd!',
+    });
+    const { refresh_token } = json(signupRes);
+    const res = await inject(app, 'GET', '/auth/me', null, { Authorization: `Bearer ${refresh_token}` });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tools/dispatcher.js
+++ b/tools/dispatcher.js
@@ -1,0 +1,30 @@
+import { callMcpTool } from './mcp-client.js';
+
+// Built-in tools that are always available without any MCP server
+const builtins = {
+  get_current_time: () => ({ time: new Date().toISOString() }),
+  get_current_date: () => ({
+    date: new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
+  }),
+};
+
+/**
+ * Dispatch a tool call to either a built-in handler or an MCP server.
+ *
+ * Tool names containing "__" are routed to MCP via callMcpTool().
+ * Everything else is matched against the builtins map.
+ *
+ * @param {string} name - Tool name (e.g. "get_current_time" or "booking__make_reservation")
+ * @param {object} args - Parsed arguments from OpenAI
+ * @param {Map} mcpClients - Active MCP client connections for this call session
+ * @returns {Promise<any>}
+ */
+export async function dispatchTool(name, args, mcpClients) {
+  if (builtins[name]) {
+    return builtins[name](args);
+  }
+  if (name.includes('__')) {
+    return callMcpTool(name, args, mcpClients);
+  }
+  throw new Error(`Unknown tool: ${name}`);
+}

--- a/tools/mcp-client.js
+++ b/tools/mcp-client.js
@@ -1,0 +1,90 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import logger from '../logger.js';
+
+/**
+ * Spin up MCP client connections for each server config from the persona.
+ * @param {Array<{name: string, command: string, args?: string[], env?: object}>} serverConfigs
+ * @returns {Promise<Map<string, Client>>}
+ */
+export async function createMcpClients(serverConfigs) {
+  const clients = new Map();
+  for (const cfg of serverConfigs || []) {
+    try {
+      const transport = new StdioClientTransport({
+        command: cfg.command,
+        args: cfg.args || [],
+        env: cfg.env,
+      });
+      const client = new Client({ name: 'ai-phone', version: '1.0.0' });
+      await client.connect(transport);
+      clients.set(cfg.name, client);
+      logger.info({ serverName: cfg.name }, 'MCP server connected');
+    } catch (err) {
+      logger.error({ err, serverName: cfg.name }, 'Failed to connect MCP server');
+    }
+  }
+  return clients;
+}
+
+/**
+ * Query each connected MCP server for its tool list and return them in
+ * OpenAI function-calling format, namespaced as "serverName__toolName".
+ * @param {Map<string, Client>} clients
+ * @returns {Promise<Array>}
+ */
+export async function getMcpTools(clients) {
+  const tools = [];
+  for (const [serverName, client] of clients) {
+    try {
+      const { tools: serverTools } = await client.listTools();
+      for (const t of serverTools) {
+        tools.push({
+          type: 'function',
+          name: `${serverName}__${t.name}`,
+          description: t.description,
+          parameters: t.inputSchema,
+        });
+      }
+    } catch (err) {
+      logger.error({ err, serverName }, 'Failed to list tools from MCP server');
+    }
+  }
+  return tools;
+}
+
+/**
+ * Invoke a namespaced tool ("serverName__toolName") on the appropriate MCP client.
+ * @param {string} namespacedTool
+ * @param {object} args
+ * @param {Map<string, Client>} clients
+ * @returns {Promise<any>}
+ */
+export async function callMcpTool(namespacedTool, args, clients) {
+  const separatorIndex = namespacedTool.indexOf('__');
+  if (separatorIndex === -1) throw new Error(`MCP tool name must include server prefix: ${namespacedTool}`);
+  const serverName = namespacedTool.slice(0, separatorIndex);
+  const toolName = namespacedTool.slice(separatorIndex + 2);
+  const client = clients.get(serverName);
+  if (!client) throw new Error(`No MCP server registered: ${serverName}`);
+  const result = await client.callTool({ name: toolName, arguments: args });
+  // Return text content directly, or raw result for callers that need more
+  if (Array.isArray(result.content) && result.content[0]?.type === 'text') {
+    return result.content[0].text;
+  }
+  return result;
+}
+
+/**
+ * Close all active MCP client connections.
+ * @param {Map<string, Client>} clients
+ */
+export async function closeMcpClients(clients) {
+  for (const [serverName, client] of clients) {
+    try {
+      await client.close();
+    } catch (err) {
+      logger.warn({ err, serverName }, 'Error closing MCP client');
+    }
+  }
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: 15000, // bcrypt can be slow
+  },
+});


### PR DESCRIPTION
## Summary

- `CLAUDE.md` — full codebase guide for AI assistants and contributors
- MCP tool calling — AI can execute real actions (bookings, lookups) during phone calls
- Real Supabase authentication wired into the frontend and all API routes
- Custom JWT OAuth system with comprehensive tests (TDD, two-commit RED → GREEN)

---

## What's included

### OAuth Auth System (two-commit TDD)
**Commit RED** — 39 tests written against empty stubs (all fail)
**Commit GREEN** — full implementation, all 39 tests pass in 612 ms

| Route | Behaviour |
|-------|-----------|
| `POST /auth/signup` | Create account; bcrypt hash; return access + refresh token pair |
| `POST /auth/login` | Verify credentials (timing-safe); return token pair |
| `POST /auth/refresh` | Validate + rotate refresh token; return new pair |
| `POST /auth/logout` | Revoke refresh token; idempotent (invalid token still 200) |
| `GET /auth/me` | Verify Bearer access token; return `{ user }` |

Security details:
- **Separate secrets** for access and refresh tokens — cross-type misuse returns 401
- **Access token jti** — unique per issuance even within the same second
- **Refresh token rotation** — old JTI is revoked before the new pair is issued
- **Timing-safe login** — dummy bcrypt compare for unknown emails prevents enumeration
- **Constant error messages** — wrong email and wrong password both return `"invalid credentials"`

Test coverage (39 cases):
- Signup: valid, duplicate email, invalid email, short password, missing fields
- Login: valid, wrong password, unknown email, enumeration check, email case-insensitivity
- Refresh: rotation, re-use of rotated token, garbage token, forged-secret token, expired token, cross-type misuse
- Logout: revocation, idempotency, invalid-token tolerance
- GET /me: valid token, missing/malformed header, expired token, forged-secret token, cross-type misuse

### MCP Tool Calling
- `tools/mcp-client.js` — MCP SDK wrapper (connect, list tools, call tool, close)
- `tools/dispatcher.js` — routes calls to built-ins or MCP servers
- `index.js` — handles `response.function_call_arguments.done`, sends `function_call_output`, triggers `response.create`
- Migration adds `tools` + `mcp_servers` JSONB columns to `personas`

### Frontend Auth Fixes
- `PrivateRoute.jsx` — real Supabase session check
- `Login.jsx` — `signInWithPassword` + `signInWithOtp` (magic link toggle)
- `App.jsx` — `/api-keys` and `/logs` now guarded

### Backend Hardening
- `GET /api/personas` protected with `verifyAuth`
- Supabase env vars required at startup (fatal exit if missing)
- `.env.example` + `frontend/.env.example` added

---

## Test plan
- [ ] `npm test` — 39 tests, all green, < 1 s
- [ ] Server starts without `SUPABASE_*` → fatal log + process exit
- [ ] `GET /api/personas` without Bearer token → 401
- [ ] Signup → login → logout → refresh after logout → 401
- [ ] `/api-keys` while unauthenticated → redirects to `/login`

https://claude.ai/code/session_01TMzwxFYUYt3fgp7qj8knAE