### PR TITLE
Mobile-first UI redesign + auth, MCP tool calling, OAuth system

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>frontend</title>
   </head>
   <body>

--- a/frontend/src/components/FAB.jsx
+++ b/frontend/src/components/FAB.jsx
@@ -5,7 +5,8 @@ const FAB = ({ onClick }) => {
   return (
     <button
       onClick={onClick}
-      className="fixed right-6 bottom-6 z-40 w-14 h-14 rounded-full bg-gradient-to-br from-primary-600 to-primary-500 text-white shadow-xl flex items-center justify-center hover:scale-105 transform transition-all"
+      className="fixed right-4 z-40 w-14 h-14 rounded-full bg-gradient-to-br from-primary-600 to-primary-500 text-white shadow-xl flex items-center justify-center hover:scale-105 transform transition-all"
+      style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom) + 1rem)' }}
       aria-label="Create Persona"
     >
       <Plus className="w-6 h-6" />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
-import { Phone, Settings, Key, ChartBar as BarChart3, FileText, Menu, X, LogOut } from 'lucide-react';
+import { Phone, Settings, Key, ChartBar as BarChart3, FileText, X, LogOut } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import { supabase } from '../lib/supabase';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const Layout = ({ children }) => {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
   const nav = useNavigate();
+  const location = useLocation();
   const navRef = useRef(null);
 
   useEffect(() => {
@@ -21,15 +22,21 @@ const Layout = ({ children }) => {
       setCurrentUser(session?.user ?? null);
     });
 
-    return () => listener.subscription.unsubscribe();
+    return () => {
+      mounted = false;
+      listener.subscription.unsubscribe();
+    };
   }, []);
 
   const navigation = [
-    { name: 'Dashboard', icon: BarChart3, href: '/', current: true },
-    { name: 'AI Configuration', icon: Settings, href: '/ai-config', current: false },
-    { name: 'API Keys', icon: Key, href: '/api-keys', current: false },
-    { name: 'Call Logs', icon: FileText, href: '/logs', current: false },
+    { name: 'Dashboard', icon: BarChart3, href: '/' },
+    { name: 'AI Config', icon: Settings, href: '/ai-config' },
+    { name: 'API Keys', icon: Key, href: '/api-keys' },
+    { name: 'Call Logs', icon: FileText, href: '/logs' },
   ];
+
+  const isActive = (href) =>
+    href === '/' ? location.pathname === '/' : location.pathname.startsWith(href);
 
   // Focus first navigation link when sidebar opens (mobile)
   useEffect(() => {
@@ -45,11 +52,12 @@ const Layout = ({ children }) => {
   }, [sidebarOpen]);
 
   return (
-  <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors">
       {/* Skip link for keyboard users */}
       <a href="#main" className="sr-only focus:not-sr-only z-50 p-2 bg-white dark:bg-gray-800 rounded mt-2 ml-2">
         Skip to main content
       </a>
+
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -60,7 +68,7 @@ const Layout = ({ children }) => {
         />
       )}
 
-      {/* Sidebar / navigation */}
+      {/* Sidebar / navigation (desktop always visible; mobile slide-in) */}
       <nav
         id="sidebar-navigation"
         ref={navRef}
@@ -70,7 +78,7 @@ const Layout = ({ children }) => {
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         } lg:translate-x-0 rounded-r-2xl shadow-lg/5`}
       >
-  <div className="flex items-center justify-between h-16 px-6 border-b border-gray-200">
+        <div className="flex items-center justify-between h-16 px-6 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center space-x-3">
             <div className="w-10 h-10 bg-gradient-to-br from-primary-500 to-primary-600 rounded-lg flex items-center justify-center shadow-md">
               <Phone className="w-5 h-5 text-white" />
@@ -88,19 +96,20 @@ const Layout = ({ children }) => {
           </button>
         </div>
 
-  <nav className="p-4 space-y-2" aria-label="Main Navigation">
+        <nav className="p-4 space-y-2" aria-label="Main Navigation">
           {navigation.map((item) => {
             const Icon = item.icon;
+            const active = isActive(item.href);
             return (
               <a
                 key={item.name}
                 href={item.href}
                 className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors ${
-                  item.current
+                  active
                     ? 'bg-primary-50 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300'
                     : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                 }`}
-                aria-current={item.current ? 'page' : undefined}
+                aria-current={active ? 'page' : undefined}
               >
                 <Icon className="w-5 h-5" />
                 <span className="font-medium">{item.name}</span>
@@ -109,12 +118,15 @@ const Layout = ({ children }) => {
           })}
         </nav>
 
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 bg-gradient-to-t from-white/50 dark:from-gray-800/50">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-700 bg-gradient-to-t from-white/50 dark:from-gray-800/50">
           <div className="flex items-center space-x-3 px-4 py-3" role="complementary" aria-label="User profile">
-            <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-700 dark:text-gray-200">U</div>
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-900 dark:text-white">User</p>
-              <p className="text-xs text-gray-500">user@example.com</p>
+            <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-700 dark:text-gray-200">
+              {currentUser?.email?.[0]?.toUpperCase() ?? 'U'}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                {currentUser?.email ?? 'Guest'}
+              </p>
             </div>
           </div>
         </div>
@@ -122,39 +134,36 @@ const Layout = ({ children }) => {
 
       {/* Main content */}
       <div className="lg:pl-64">
-        {/* Top bar / banner */}
+        {/* Top header */}
         <header role="banner" className="sticky top-0 z-10 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center justify-between h-16 px-6">
-            <button
-              onClick={() => setSidebarOpen(true)}
-              className="lg:hidden text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
-              aria-label="Open sidebar"
-              aria-controls="sidebar-navigation"
-              aria-expanded={sidebarOpen}
-            >
-              <Menu className="w-6 h-6" />
-            </button>
-            <div className="flex items-center space-x-4 ml-auto">
-              <div className="flex items-center space-x-4">
-                <div className="flex items-center space-x-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
-                  <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                  <span className="text-sm text-gray-600 dark:text-gray-300">Connected</span>
-                </div>
-                <ThemeToggle />
+          <div className="flex items-center justify-between h-12 lg:h-16 px-4 lg:px-6">
+            {/* Logo wordmark — visible on mobile since there's no hamburger */}
+            <div className="flex items-center space-x-2 lg:hidden">
+              <div className="w-7 h-7 bg-gradient-to-br from-primary-500 to-primary-600 rounded-md flex items-center justify-center">
+                <Phone className="w-4 h-4 text-white" />
               </div>
+              <span className="font-semibold text-sm text-gray-900 dark:text-white">AI Assistant</span>
+            </div>
+
+            <div className="flex items-center space-x-3 ml-auto">
+              <div className="flex items-center space-x-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
+                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+                <span className="text-sm text-gray-600 dark:text-gray-300 hidden sm:inline">Connected</span>
+              </div>
+              <ThemeToggle />
 
               {/* Auth controls */}
-              <div className="ml-4 relative">
+              <div className="relative">
                 {!currentUser ? (
                   <button
                     onClick={() => nav('/login')}
-                    className="px-3 py-1 rounded-md bg-primary-600 text-white"
+                    className="px-3 py-1 rounded-md bg-primary-600 text-white text-sm"
                   >
                     Sign in
                   </button>
                 ) : (
                   <div className="flex items-center space-x-2">
-                    <div className="w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-sm text-gray-800 dark:text-gray-200">
+                    <div className="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-sm text-gray-800 dark:text-gray-200">
                       {currentUser?.email?.[0]?.toUpperCase()}
                     </div>
                     <button
@@ -175,8 +184,42 @@ const Layout = ({ children }) => {
         </header>
 
         {/* Page content */}
-        <main className="p-6">{children}</main>
+        <main id="main" className="p-4 pb-[calc(3.5rem+env(safe-area-inset-bottom)+1rem)] lg:p-6 lg:pb-6">
+          {children}
+        </main>
       </div>
+
+      {/* Bottom tab bar — mobile only */}
+      <nav
+        aria-label="Bottom Navigation"
+        className="fixed bottom-0 inset-x-0 z-30 lg:hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 flex"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        {navigation.map((item) => {
+          const Icon = item.icon;
+          const active = isActive(item.href);
+          return (
+            <a
+              key={item.name}
+              href={item.href}
+              className="flex-1 flex flex-col items-center justify-center gap-0.5 py-2 min-h-[56px] relative"
+              aria-current={active ? 'page' : undefined}
+            >
+              {active && (
+                <span className="absolute top-0 left-1/2 -translate-x-1/2 w-8 h-0.5 bg-primary-600 rounded-full" />
+              )}
+              <Icon
+                className={`w-6 h-6 ${active ? 'text-primary-600 dark:text-primary-400' : 'text-gray-500 dark:text-gray-400'}`}
+              />
+              <span
+                className={`text-[10px] font-medium ${active ? 'text-primary-600 dark:text-primary-400' : 'text-gray-500 dark:text-gray-400'}`}
+              >
+                {item.name}
+              </span>
+            </a>
+          );
+        })}
+      </nav>
     </div>
   );
 };

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -65,29 +65,34 @@ const Modal = ({ open, onClose, children, title }) => {
   if (!open) return null;
 
   return (
-    <div 
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+    <div
+      className="fixed inset-0 z-50 flex items-end lg:items-center lg:justify-center lg:p-6"
       role="dialog"
       aria-modal="true"
       aria-labelledby="modal-title"
       onKeyDown={handleTabKey}
     >
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-      <div 
+      <div
         ref={modalRef}
-        className="relative w-full sm:max-w-3xl bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-2xl z-10"
+        className="relative w-full lg:max-w-3xl bg-white dark:bg-gray-800 rounded-t-2xl lg:rounded-2xl shadow-2xl z-10 max-h-[85vh] overflow-y-auto"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
-        <div className="flex items-center justify-between mb-4">
+        {/* Drag handle — mobile only */}
+        <div className="lg:hidden flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full" />
+        </div>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
-          <button 
+          <button
             onClick={onClose}
-            className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 transition-colors"
+            className="p-2.5 w-10 h-10 flex items-center justify-center text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
             aria-label="Close modal"
           >
             <X className="w-5 h-5" />
           </button>
         </div>
-        <div className="text-gray-600 dark:text-gray-300">{children}</div>
+        <div className="px-6 py-4 text-gray-600 dark:text-gray-300">{children}</div>
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,3 +22,6 @@ body { color: var(--color-text); }
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+.scrollbar-none { scrollbar-width: none; }
+.scrollbar-none::-webkit-scrollbar { display: none; }

--- a/frontend/src/pages/AIConfig.jsx
+++ b/frontend/src/pages/AIConfig.jsx
@@ -1,40 +1,63 @@
 import { useState, useEffect, useRef } from 'react';
-import { Save, RefreshCw } from 'lucide-react';
+import { Save, RefreshCw, Plus } from 'lucide-react';
 import { supabase } from '../lib/supabase';
-import PersonaCard from '../components/PersonaCard';
 import FAB from '../components/FAB';
 import Modal from '../components/Modal';
 import AudioPlayer from '../components/AudioPlayer';
 
+const voices = [
+  { id: 'alloy', name: 'Alloy', description: 'Neutral, balanced' },
+  { id: 'echo', name: 'Echo', description: 'Warm, friendly' },
+  { id: 'fable', name: 'Fable', description: 'Expressive' },
+  { id: 'onyx', name: 'Onyx', description: 'Deep, authoritative' },
+  { id: 'nova', name: 'Nova', description: 'Bright, energetic' },
+  { id: 'shimmer', name: 'Shimmer', description: 'Soft, soothing' },
+];
+
+const BLANK_PERSONA = {
+  name: 'New Persona',
+  system_message:
+    'You are the phone assistant for Kitchener Thai Massage. Speak in a friendly, bright, and professional tone with a subtle Canadian-English cadence. Use English only. Keep sentences short and clear, and pause briefly after questions. When booking, collect service, date/time, name, and phone number, then repeat to confirm. If asked, offer to transfer to a human. Do not use Thai.',
+  voice: 'shimmer',
+  temperature: 0.25,
+  initial_greeting: 'Hello, Kitchener Thai Massage. How can I help you today?',
+  enable_greeting: true,
+  is_active: false,
+};
+
+function ToggleSwitch({ checked, onChange, label }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex w-11 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+        checked ? 'bg-primary-600' : 'bg-gray-200 dark:bg-gray-600'
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transform transition-transform ${
+          checked ? 'translate-x-5' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
 const AIConfig = () => {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [config, setConfig] = useState({
-    name: 'Default Configuration',
-    system_message:
-      'You are the phone assistant for Kitchener Thai Massage. Speak in a friendly, bright, and professional tone with a subtle Canadian-English cadence. Use English only. Keep sentences short and clear, and pause briefly after questions to allow the caller to respond. When handling bookings, collect service, preferred date, preferred time, full name, and phone number. Repeat booking details to confirm before ending the call. If the caller requests a human, offer to transfer. If calls are recorded, say: "This call may be recorded for quality and booking confirmation purposes." Always respond in English and do not use Thai.',
-    voice: 'shimmer',
-    temperature: 0.25,
-    initial_greeting: 'Hello, Kitchener Thai Massage. How can I help you today?',
-    enable_greeting: true,
-    is_active: false,
-  });
+  const [config, setConfig] = useState({ ...BLANK_PERSONA });
   const [initialConfig, setInitialConfig] = useState(null);
   const [personas, setPersonas] = useState([]);
   const [selectedPersonaId, setSelectedPersonaId] = useState(null);
   const [previewAudioUrl, setPreviewAudioUrl] = useState(null);
   const [previewPersona, setPreviewPersona] = useState(null);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
   const fileInputRef = useRef(null);
-
-  const voices = [
-    { id: 'alloy', name: 'Alloy', description: 'Neutral and balanced' },
-    { id: 'echo', name: 'Echo', description: 'Warm and friendly' },
-    { id: 'fable', name: 'Fable', description: 'Expressive and dynamic' },
-    { id: 'onyx', name: 'Onyx', description: 'Deep and authoritative' },
-    { id: 'nova', name: 'Nova', description: 'Bright and energetic' },
-    { id: 'shimmer', name: 'Shimmer', description: 'Soft and soothing' },
-  ];
 
   useEffect(() => {
     fetchConfig();
@@ -77,12 +100,8 @@ const AIConfig = () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user) {
-      setSaving(false);
-      return;
-    }
+    if (!user) { setSaving(false); return; }
 
-    // Save as a persona if persona selected, otherwise save assistant_settings
     if (selectedPersonaId) {
       await supabase.from('personas').update(config).eq('id', selectedPersonaId);
     } else if (config.id) {
@@ -97,7 +116,7 @@ const AIConfig = () => {
     setTimeout(() => setMessage(''), 3000);
   };
 
-  const handleSelectPersona = async (persona) => {
+  const handleSelectPersona = (persona) => {
     setSelectedPersonaId(persona.id);
     setConfig(persona);
     setInitialConfig(persona);
@@ -109,8 +128,7 @@ const AIConfig = () => {
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return;
-    const payload = { ...config, user_id: user.id };
-    const { data } = await supabase.from('personas').insert([payload]).select().single();
+    await supabase.from('personas').insert([{ ...config, user_id: user.id }]).select().single();
     await fetchPersonas();
     setSaving(false);
     setMessage('Persona created');
@@ -121,12 +139,7 @@ const AIConfig = () => {
     if (!window.confirm('Set this persona as active?')) return;
     setSaving(true);
     await supabase.from('personas').update({ is_active: false }).eq('is_active', true);
-    const { data } = await supabase
-      .from('personas')
-      .update({ is_active: true })
-      .eq('id', id)
-      .select()
-      .single();
+    await supabase.from('personas').update({ is_active: true }).eq('id', id).select().single();
     await fetchPersonas();
     setSaving(false);
     setMessage('Persona activated');
@@ -135,207 +148,193 @@ const AIConfig = () => {
 
   const isDirty = () => {
     if (!initialConfig) return true;
-    try {
-      return JSON.stringify(initialConfig) !== JSON.stringify(config);
-    } catch (e) {
-      return true;
-    }
+    try { return JSON.stringify(initialConfig) !== JSON.stringify(config); } catch { return true; }
   };
 
   const handleActiveToggle = (checked) => {
-    if (checked) {
-      const confirmMsg = 'Set this configuration as active? This will be used for incoming calls.';
-      if (!window.confirm(confirmMsg)) return;
-    }
+    if (checked && !window.confirm('Set this configuration as active? This will be used for incoming calls.')) return;
     setConfig({ ...config, is_active: checked });
-  };
-
-  const handleImportPreviewFile = (file) => {
-    try {
-      if (!file) return;
-      // cleanup previous preview if any
-      if (previewAudioUrl) URL.revokeObjectURL(previewAudioUrl);
-      const url = URL.createObjectURL(file);
-      setPreviewAudioUrl(url);
-      setPreviewPersona({ name: file.name });
-      setPreviewOpen(true);
-    } catch (err) {
-      console.error('import preview error', err);
-      alert('Failed to open local preview');
-    }
   };
 
   const handleFileInputChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    handleImportPreviewFile(file);
-    // reset input so the same file can be re-selected later
+    if (previewAudioUrl) URL.revokeObjectURL(previewAudioUrl);
+    setPreviewAudioUrl(URL.createObjectURL(file));
+    setPreviewPersona({ name: file.name });
+    setPreviewOpen(true);
     e.target.value = '';
   };
 
+  const initials = (name) =>
+    name
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((w) => w[0]?.toUpperCase() ?? '')
+      .join('');
+
+  const gradients = [
+    'from-purple-500 to-indigo-500',
+    'from-pink-500 to-rose-500',
+    'from-teal-500 to-cyan-500',
+    'from-orange-500 to-amber-500',
+    'from-green-500 to-emerald-500',
+  ];
+
+  const personaGradient = (id) => gradients[id.charCodeAt(0) % gradients.length];
+
   return (
-    <div className="space-y-6 max-w-4xl mx-auto">
-      {/* Persona list */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-medium">Personas</h2>
-        <div className="flex items-center space-x-2">
+    <div className="space-y-5 max-w-4xl mx-auto">
+      {/* ── Persona chip carousel ───────────────────────────────────── */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Personas</h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 rounded-lg"
+            >
+              Open Preview
+            </button>
+            <button
+              onClick={handleCreatePersona}
+              disabled={saving}
+              className="px-3 py-1.5 text-sm bg-primary-600 text-white rounded-lg disabled:opacity-50"
+            >
+              Create
+            </button>
+          </div>
+        </div>
+
+        <input ref={fileInputRef} onChange={handleFileInputChange} type="file" accept="audio/*" className="hidden" />
+
+        {/* Chip carousel */}
+        <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory -mx-4 px-4 pb-2 scrollbar-none">
+          {/* "New" chip */}
           <button
             onClick={() => {
               setSelectedPersonaId(null);
-              setConfig({
-                name: 'New Persona',
-                system_message:
-                  'You are the phone assistant for Kitchener Thai Massage. Speak in a friendly, bright, and professional tone with a subtle Canadian-English cadence. Use English only. Keep sentences short and clear, and pause briefly after questions. When booking, collect service, date/time, name, and phone number, then repeat to confirm. If asked, offer to transfer to a human. Do not use Thai.',
-                voice: 'shimmer',
-                temperature: 0.25,
-                initial_greeting: 'Hello, Kitchener Thai Massage. How can I help you today?',
-                enable_greeting: true,
-                is_active: false,
-              });
+              setConfig({ ...BLANK_PERSONA });
               setInitialConfig(null);
             }}
-            className="px-3 py-1 text-sm bg-gray-100 rounded"
+            className="snap-start flex-shrink-0 flex flex-col items-center gap-1"
           >
-            New Persona
+            <div className="w-12 h-12 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center">
+              <Plus className="w-5 h-5 text-gray-400" />
+            </div>
+            <span className="text-[10px] text-gray-500 w-12 text-center truncate">New</span>
           </button>
-          <button
-            onClick={() => fileInputRef.current && fileInputRef.current.click()}
-            className="px-3 py-1 text-sm bg-gray-50 rounded border border-gray-200"
-          >
-            Open Local Preview
-          </button>
-          <button
-            onClick={handleCreatePersona}
-            disabled={saving}
-            className="px-3 py-1 text-sm bg-primary-600 text-white rounded disabled:opacity-50"
-          >
-            Create from Form
-          </button>
-        </div>
-      </div>
 
-      {/* hidden file input for local preview import */}
-      <input
-        ref={fileInputRef}
-        onChange={handleFileInputChange}
-        type="file"
-        accept="audio/*"
-        style={{ display: 'none' }}
-      />
-
-      <div>
-        <div className="overflow-x-auto -mx-4 px-4">
-          <div className="inline-flex gap-4 py-2 min-w-[640px]">
-            {personas.map((p) => (
-              <div key={p.id} className="w-64">
-                <PersonaCard
-                  persona={p}
-                  onEdit={(persona) => handleSelectPersona(persona)}
-                  onActivate={(id) => handleActivatePersona(id)}
-                  onPreview={async (persona) => {
-                    // fetch preview audio and play inline in modal
-                    try {
-                      const res = await fetch(`/api/personas/${persona.id}/preview`, { method: 'POST' });
-                      if (!res.ok) throw new Error('preview failed');
-                      const json = await res.json();
-                      const bytes = Uint8Array.from(atob(json.audio_base64), (c) => c.charCodeAt(0));
-                      const blob = new Blob([bytes], { type: json.content_type || 'audio/wav' });
-                      const url = URL.createObjectURL(blob);
-                      // open preview modal with audio player
-                      // cleanup previous preview if any
-                      if (previewAudioUrl) URL.revokeObjectURL(previewAudioUrl);
-                      setPreviewAudioUrl(url);
-                      setPreviewPersona(persona);
-                      setPreviewOpen(true);
-                    } catch (err) {
-                      console.error('preview error', err);
-                      alert('Preview failed');
-                    }
-                  }}
-                />
+          {personas.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => handleSelectPersona(p)}
+              className="snap-start flex-shrink-0 flex flex-col items-center gap-1"
+            >
+              <div
+                className={`w-12 h-12 rounded-full bg-gradient-to-br ${personaGradient(p.id)} flex items-center justify-center text-white text-sm font-bold shadow ${
+                  selectedPersonaId === p.id ? 'ring-2 ring-primary-500 ring-offset-2' : ''
+                }`}
+              >
+                {initials(p.name)}
               </div>
-            ))}
-          </div>
+              <span className="text-[10px] text-gray-600 dark:text-gray-300 w-12 text-center truncate">
+                {p.name.split(/\s+/)[0]}
+              </span>
+            </button>
+          ))}
         </div>
       </div>
+
+      {/* ── Header ──────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">AI Configuration</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Customize your AI assistant's behavior and personality
-          </p>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">AI Configuration</h1>
+          <p className="mt-0.5 text-sm text-gray-500">Customize behavior and personality</p>
         </div>
-        <div className="flex items-center space-x-4">
-          {message && <div className="text-sm text-green-600">{message}</div>}
+        <div className="flex items-center gap-3">
+          {message && <span className="text-sm text-green-600 hidden sm:block">{message}</span>}
           <button
             onClick={handleSave}
             disabled={saving || !isDirty()}
-            className="flex items-center space-x-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 transition-colors"
           >
             {saving ? (
-              <>
-                <RefreshCw className="w-4 h-4 animate-spin" />
-                <span>Saving...</span>
-              </>
+              <RefreshCw className="w-4 h-4 animate-spin" />
             ) : (
-              <>
-                <Save className="w-4 h-4" />
-                <span>Save Changes</span>
-              </>
+              <Save className="w-4 h-4" />
             )}
+            <span className="hidden sm:inline">{saving ? 'Saving…' : 'Save'}</span>
           </button>
         </div>
       </div>
 
-      <div className="bg-white rounded-lg shadow">
-        <div className="p-6 space-y-6">
-          {/* Configuration Name */}
+      {message && <p className="text-sm text-green-600 sm:hidden">{message}</p>}
+
+      {/* ── Config form card ────────────────────────────────────────── */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow">
+        <div className="p-4 lg:p-6 space-y-5">
+          {/* Name */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Configuration Name
             </label>
             <input
               type="text"
               value={config.name}
               onChange={(e) => setConfig({ ...config, name: e.target.value })}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              className="w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               placeholder="My Configuration"
             />
           </div>
 
-          {/* System Message */}
+          {/* System Prompt with progressive disclosure */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               System Prompt
-              <span className="ml-2 text-xs text-gray-500">
-                Define your AI's personality and behavior
+              <span className="ml-2 text-xs text-gray-500 font-normal">
+                Define your AI's personality
               </span>
             </label>
-            <textarea
-              value={config.system_message}
-              onChange={(e) => setConfig({ ...config, system_message: e.target.value })}
-              rows={6}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-              placeholder="You are a helpful assistant..."
-            />
+            <div className="relative">
+              <textarea
+                value={config.system_message}
+                onChange={(e) => setConfig({ ...config, system_message: e.target.value })}
+                rows={promptExpanded ? 7 : 2}
+                onClick={() => setPromptExpanded(true)}
+                className="w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none transition-all"
+                placeholder="You are a helpful assistant…"
+              />
+              {!promptExpanded && (
+                <div className="absolute bottom-0 inset-x-0 h-8 bg-gradient-to-t from-white dark:from-gray-700 to-transparent pointer-events-none rounded-b-xl" />
+              )}
+            </div>
+            <button
+              type="button"
+              className="mt-1 text-xs text-primary-600 dark:text-primary-400"
+              onClick={() => setPromptExpanded(!promptExpanded)}
+            >
+              {promptExpanded ? 'Show less' : 'Show more'}
+            </button>
           </div>
 
-          {/* Voice Selection */}
+          {/* Voice — always 3 cols */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Voice</label>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Voice</label>
+            <div className="grid grid-cols-3 gap-2">
               {voices.map((voice) => (
                 <button
                   key={voice.id}
+                  type="button"
                   onClick={() => setConfig({ ...config, voice: voice.id })}
-                  className={`p-4 border-2 rounded-lg text-left transition-all ${
+                  className={`p-3 min-h-[64px] border-2 rounded-xl text-left transition-all ${
                     config.voice === voice.id
-                      ? 'border-primary-500 bg-primary-50'
-                      : 'border-gray-200 hover:border-gray-300'
+                      ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/30'
+                      : 'border-gray-200 dark:border-gray-600 hover:border-gray-300'
                   }`}
                 >
-                  <div className="font-medium text-gray-900">{voice.name}</div>
-                  <div className="text-sm text-gray-500 mt-1">{voice.description}</div>
+                  <div className="text-sm font-medium text-gray-900 dark:text-white">{voice.name}</div>
+                  <div className="text-[11px] text-gray-500 mt-0.5 leading-tight">{voice.description}</div>
                 </button>
               ))}
             </div>
@@ -343,11 +342,9 @@ const AIConfig = () => {
 
           {/* Temperature */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
               Temperature: {config.temperature}
-              <span className="ml-2 text-xs text-gray-500">
-                Controls randomness (0 = focused, 1 = creative)
-              </span>
+              <span className="ml-2 text-xs text-gray-500 font-normal">0 = focused · 1 = creative</span>
             </label>
             <input
               type="range"
@@ -356,7 +353,7 @@ const AIConfig = () => {
               step="0.1"
               value={config.temperature}
               onChange={(e) => setConfig({ ...config, temperature: parseFloat(e.target.value) })}
-              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-primary-600"
             />
             <div className="flex justify-between text-xs text-gray-500 mt-1">
               <span>More Focused</span>
@@ -364,48 +361,42 @@ const AIConfig = () => {
             </div>
           </div>
 
-          {/* Initial Greeting */}
+          {/* Initial Greeting with toggle switch */}
           <div>
             <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium text-gray-700">Initial Greeting</label>
-              <label className="flex items-center space-x-2">
-                <input
-                  type="checkbox"
-                  checked={config.enable_greeting}
-                  onChange={(e) => setConfig({ ...config, enable_greeting: e.target.checked })}
-                  className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
-                />
-                <span className="text-sm text-gray-600">Enable</span>
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Initial Greeting
               </label>
+              <ToggleSwitch
+                checked={config.enable_greeting}
+                onChange={(v) => setConfig({ ...config, enable_greeting: v })}
+                label="Enable greeting"
+              />
             </div>
-            <input
-              type="text"
-              value={config.initial_greeting}
-              onChange={(e) => setConfig({ ...config, initial_greeting: e.target.value })}
-              disabled={!config.enable_greeting}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:bg-gray-100 disabled:text-gray-500"
-              placeholder="Hello! How can I help you today?"
-            />
+            {config.enable_greeting && (
+              <input
+                type="text"
+                value={config.initial_greeting}
+                onChange={(e) => setConfig({ ...config, initial_greeting: e.target.value })}
+                className="w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="Hello! How can I help you today?"
+              />
+            )}
           </div>
 
-          {/* Active Status */}
-          <div className="pt-4 border-t border-gray-200">
-            <label className="flex items-center space-x-3">
-              <input
-                type="checkbox"
-                checked={config.is_active}
-                onChange={(e) => handleActiveToggle(e.target.checked)}
-                className="w-5 h-5 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
-              />
-              <div>
-                <span className="text-sm font-medium text-gray-900">
-                  Set as Active Configuration
-                </span>
-                <p className="text-xs text-gray-500">
-                  This configuration will be used for incoming calls
-                </p>
+          {/* Active Status — full-row tap zone with toggle */}
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={() => handleActiveToggle(!config.is_active)}
+              className="w-full flex items-center justify-between p-4 rounded-xl border border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+            >
+              <div className="text-left">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">Set as Active Configuration</p>
+                <p className="text-xs text-gray-500 mt-0.5">This configuration will be used for incoming calls</p>
               </div>
-            </label>
+              <ToggleSwitch checked={config.is_active} onChange={handleActiveToggle} label="Set active" />
+            </button>
           </div>
         </div>
       </div>
@@ -415,29 +406,28 @@ const AIConfig = () => {
         open={!!selectedPersonaId || initialConfig === null}
         onClose={() => {
           setSelectedPersonaId(null);
-          // reset to last saved config
           fetchConfig();
         }}
         title={selectedPersonaId ? 'Edit Persona' : 'New Persona'}
       >
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Name</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Name</label>
             <input
               type="text"
               value={config.name}
               onChange={(e) => setConfig({ ...config, name: e.target.value })}
-              className="w-full px-3 py-2 border rounded"
+              className="w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">System Prompt</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">System Prompt</label>
             <textarea
-              rows={4}
+              rows={5}
               value={config.system_message}
               onChange={(e) => setConfig({ ...config, system_message: e.target.value })}
-              className="w-full px-3 py-2 border rounded"
+              className="w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
             />
           </div>
 
@@ -448,28 +438,22 @@ const AIConfig = () => {
                   await supabase.from('personas').update(config).eq('id', selectedPersonaId);
                   setMessage('Persona updated');
                 } else {
-                  const {
-                    data: { user },
-                  } = await supabase.auth.getUser();
+                  const { data: { user } } = await supabase.auth.getUser();
                   if (!user) return alert('Sign in to create personas');
                   await supabase.from('personas').insert([{ ...config, user_id: user.id }]);
                   setMessage('Persona created');
                 }
                 setTimeout(() => setMessage(''), 2500);
                 fetchPersonas();
-                // close modal
                 setSelectedPersonaId(null);
               }}
-              className="px-4 py-2 bg-primary-600 text-white rounded"
+              className="flex-1 py-3 bg-primary-600 text-white rounded-xl font-medium"
             >
               Save Persona
             </button>
             <button
-              onClick={() => {
-                setSelectedPersonaId(null);
-                fetchConfig();
-              }}
-              className="px-4 py-2 bg-gray-100 rounded"
+              onClick={() => { setSelectedPersonaId(null); fetchConfig(); }}
+              className="flex-1 py-3 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-xl font-medium"
             >
               Cancel
             </button>
@@ -477,15 +461,12 @@ const AIConfig = () => {
         </div>
       </Modal>
 
-      {/* Preview Modal with inline audio player */}
+      {/* Preview Modal */}
       <Modal
         open={previewOpen}
         onClose={() => {
           setPreviewOpen(false);
-          if (previewAudioUrl) {
-            URL.revokeObjectURL(previewAudioUrl);
-            setPreviewAudioUrl(null);
-          }
+          if (previewAudioUrl) { URL.revokeObjectURL(previewAudioUrl); setPreviewAudioUrl(null); }
           setPreviewPersona(null);
         }}
         title={previewPersona ? `Preview: ${previewPersona.name}` : 'Preview'}
@@ -494,25 +475,18 @@ const AIConfig = () => {
           {previewAudioUrl ? (
             <AudioPlayer audioUrl={previewAudioUrl} />
           ) : (
-            <div className="text-sm text-gray-500">Loading preview...</div>
+            <p className="text-sm text-gray-500">Loading preview…</p>
           )}
         </div>
       </Modal>
 
-      <FAB onClick={() => {
-        setSelectedPersonaId(null);
-        setInitialConfig(null);
-        setConfig({
-          name: 'New Persona',
-          system_message:
-            'You are the phone assistant for Kitchener Thai Massage. Speak in a friendly, bright, and professional tone with a subtle Canadian-English cadence. Use English only. Keep sentences short and clear, and pause briefly after questions. When booking, collect service, date/time, name, and phone number, then repeat to confirm. If asked, offer to transfer to a human. Do not use Thai.',
-          voice: 'shimmer',
-          temperature: 0.25,
-          initial_greeting: 'Hello, Kitchener Thai Massage. How can I help you today?',
-          enable_greeting: true,
-          is_active: false,
-        });
-      }} />
+      <FAB
+        onClick={() => {
+          setSelectedPersonaId(null);
+          setInitialConfig(null);
+          setConfig({ ...BLANK_PERSONA });
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/APIKeys.jsx
+++ b/frontend/src/pages/APIKeys.jsx
@@ -5,18 +5,14 @@ import {
   Save,
   RefreshCw,
   ExternalLink,
-  CircleCheck as CheckCircle,
-  Circle as XCircle,
+  Clipboard,
 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 
 const APIKeys = () => {
   const [saving, setSaving] = useState(false);
-  const [showKeys, setShowKeys] = useState({
-    openai: false,
-    twilio_auth: false,
-    ngrok: false,
-  });
+  const [copied, setCopied] = useState(false);
+  const [showKeys, setShowKeys] = useState({ openai: false, twilio_auth: false, ngrok: false });
   const [config, setConfig] = useState({
     openai_api_key: '',
     twilio_account_sid: '',
@@ -59,10 +55,7 @@ const APIKeys = () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user) {
-      setSaving(false);
-      return;
-    }
+    if (!user) { setSaving(false); return; }
 
     const { data: existing } = await supabase
       .from('assistant_settings')
@@ -74,211 +67,173 @@ const APIKeys = () => {
     if (existing) {
       await supabase.from('assistant_settings').update(config).eq('id', existing.id);
     } else {
-      await supabase
-        .from('assistant_settings')
-        .insert([{ ...config, user_id: user.id, is_active: true }]);
+      await supabase.from('assistant_settings').insert([{ ...config, user_id: user.id, is_active: true }]);
     }
 
     setSaving(false);
   };
 
-  const toggleShowKey = (key) => {
-    setShowKeys({ ...showKeys, [key]: !showKeys[key] });
+  const toggleShowKey = (key) => setShowKeys({ ...showKeys, [key]: !showKeys[key] });
+
+  const copyWebhook = () => {
+    navigator.clipboard.writeText(webhookUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
-  const maskKey = (key, visible) => {
-    if (!key) return '';
-    if (visible) return key;
-    return '*'.repeat(Math.min(key.length, 40));
-  };
+  const inputClass =
+    'w-full px-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent';
 
-  const copyToClipboard = (text) => {
-    navigator.clipboard.writeText(text);
-  };
+  const sectionHeader = (title, desc, href, linkLabel) => (
+    <div className="px-4 lg:px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+      <div>
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h2>
+        <p className="text-sm text-gray-500">{desc}</p>
+      </div>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700 flex-shrink-0 ml-4"
+      >
+        <span className="hidden sm:inline">{linkLabel}</span>
+        <ExternalLink className="w-4 h-4" />
+      </a>
+    </div>
+  );
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5 max-w-2xl mx-auto">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">API Keys</h1>
-          <p className="mt-1 text-sm text-gray-500">Configure your API keys and credentials</p>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">API Keys</h1>
+          <p className="mt-0.5 text-sm text-gray-500">Configure your API keys and credentials</p>
         </div>
         <button
           onClick={handleSave}
           disabled={saving}
-          className="flex items-center space-x-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          className="flex items-center gap-2 px-4 py-2.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 transition-colors"
         >
           {saving ? (
-            <>
-              <RefreshCw className="w-4 h-4 animate-spin" />
-              <span>Saving...</span>
-            </>
+            <RefreshCw className="w-4 h-4 animate-spin" />
           ) : (
-            <>
-              <Save className="w-4 h-4" />
-              <span>Save Keys</span>
-            </>
+            <Save className="w-4 h-4" />
           )}
+          <span className="hidden sm:inline">{saving ? 'Saving…' : 'Save Keys'}</span>
         </button>
       </div>
 
-      {/* OpenAI Section */}
-      <div className="bg-white rounded-lg shadow">
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">OpenAI</h2>
-            <p className="text-sm text-gray-500">Configure OpenAI API access</p>
-          </div>
-          <a
-            href="https://platform.openai.com/api-keys"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700"
+      {/* OpenAI */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow overflow-hidden">
+        {sectionHeader('OpenAI', 'Configure OpenAI API access', 'https://platform.openai.com/api-keys', 'Get API Key')}
+        <div className="p-4 lg:p-6">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">API Key</label>
+          <input
+            type={showKeys.openai ? 'text' : 'password'}
+            value={config.openai_api_key}
+            onChange={(e) => setConfig({ ...config, openai_api_key: e.target.value })}
+            className={inputClass}
+            placeholder="sk-…"
+            autoComplete="off"
+          />
+          <button
+            onClick={() => toggleShowKey('openai')}
+            className="flex items-center gap-1.5 text-xs text-primary-600 dark:text-primary-400 mt-2 py-1.5 px-3 ml-auto rounded-lg"
           >
-            <span>Get API Key</span>
-            <ExternalLink className="w-4 h-4" />
-          </a>
-        </div>
-        <div className="p-6">
-          <label className="block text-sm font-medium text-gray-700 mb-2">API Key</label>
-          <div className="flex space-x-2">
-            <input
-              type={showKeys.openai ? 'text' : 'password'}
-              value={config.openai_api_key}
-              onChange={(e) => setConfig({ ...config, openai_api_key: e.target.value })}
-              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-              placeholder="sk-..."
-            />
-            <button
-              onClick={() => toggleShowKey('openai')}
-              className="px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-            >
-              {showKeys.openai ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-            </button>
-          </div>
+            {showKeys.openai ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+            {showKeys.openai ? 'Hide' : 'Show'} key
+          </button>
         </div>
       </div>
 
-      {/* Twilio Section */}
-      <div className="bg-white rounded-lg shadow">
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+      {/* Twilio */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow overflow-hidden">
+        {sectionHeader('Twilio', 'Configure Twilio phone service', 'https://console.twilio.com', 'Open Console')}
+        <div className="p-4 lg:p-6 space-y-4">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">Twilio</h2>
-            <p className="text-sm text-gray-500">Configure Twilio phone service</p>
-          </div>
-          <a
-            href="https://console.twilio.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700"
-          >
-            <span>Open Console</span>
-            <ExternalLink className="w-4 h-4" />
-          </a>
-        </div>
-        <div className="p-6 space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Account SID</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Account SID</label>
             <input
               type="text"
               value={config.twilio_account_sid}
               onChange={(e) => setConfig({ ...config, twilio_account_sid: e.target.value })}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-              placeholder="AC..."
+              className={inputClass}
+              placeholder="AC…"
+              autoComplete="off"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Auth Token</label>
-            <div className="flex space-x-2">
-              <input
-                type={showKeys.twilio_auth ? 'text' : 'password'}
-                value={config.twilio_auth_token}
-                onChange={(e) => setConfig({ ...config, twilio_auth_token: e.target.value })}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                placeholder="Your auth token"
-              />
-              <button
-                onClick={() => toggleShowKey('twilio_auth')}
-                className="px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-              >
-                {showKeys.twilio_auth ? (
-                  <EyeOff className="w-5 h-5" />
-                ) : (
-                  <Eye className="w-5 h-5" />
-                )}
-              </button>
-            </div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Auth Token</label>
+            <input
+              type={showKeys.twilio_auth ? 'text' : 'password'}
+              value={config.twilio_auth_token}
+              onChange={(e) => setConfig({ ...config, twilio_auth_token: e.target.value })}
+              className={inputClass}
+              placeholder="Your auth token"
+              autoComplete="off"
+            />
+            <button
+              onClick={() => toggleShowKey('twilio_auth')}
+              className="flex items-center gap-1.5 text-xs text-primary-600 dark:text-primary-400 mt-2 py-1.5 px-3 ml-auto rounded-lg"
+            >
+              {showKeys.twilio_auth ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+              {showKeys.twilio_auth ? 'Hide' : 'Show'} token
+            </button>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Phone Number</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Phone Number</label>
             <input
               type="text"
               value={config.twilio_phone_number}
               onChange={(e) => setConfig({ ...config, twilio_phone_number: e.target.value })}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              className={inputClass}
               placeholder="+1234567890"
             />
           </div>
         </div>
       </div>
 
-      {/* ngrok Section */}
-      <div className="bg-white rounded-lg shadow">
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+      {/* ngrok */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow overflow-hidden">
+        {sectionHeader('ngrok', 'Configure ngrok tunnel (optional)', 'https://dashboard.ngrok.com/get-started/your-authtoken', 'Get Token')}
+        <div className="p-4 lg:p-6 space-y-4">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">ngrok</h2>
-            <p className="text-sm text-gray-500">Configure ngrok tunnel (optional)</p>
-          </div>
-          <a
-            href="https://dashboard.ngrok.com/get-started/your-authtoken"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700"
-          >
-            <span>Get Auth Token</span>
-            <ExternalLink className="w-4 h-4" />
-          </a>
-        </div>
-        <div className="p-6 space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Auth Token</label>
-            <div className="flex space-x-2">
-              <input
-                type={showKeys.ngrok ? 'text' : 'password'}
-                value={config.ngrok_auth_token}
-                onChange={(e) => setConfig({ ...config, ngrok_auth_token: e.target.value })}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                placeholder="Your ngrok auth token"
-              />
-              <button
-                onClick={() => toggleShowKey('ngrok')}
-                className="px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-              >
-                {showKeys.ngrok ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-              </button>
-            </div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">Auth Token</label>
+            <input
+              type={showKeys.ngrok ? 'text' : 'password'}
+              value={config.ngrok_auth_token}
+              onChange={(e) => setConfig({ ...config, ngrok_auth_token: e.target.value })}
+              className={inputClass}
+              placeholder="Your ngrok auth token"
+              autoComplete="off"
+            />
+            <button
+              onClick={() => toggleShowKey('ngrok')}
+              className="flex items-center gap-1.5 text-xs text-primary-600 dark:text-primary-400 mt-2 py-1.5 px-3 ml-auto rounded-lg"
+            >
+              {showKeys.ngrok ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+              {showKeys.ngrok ? 'Hide' : 'Show'} token
+            </button>
           </div>
 
-          {/* Webhook URL */}
-          <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <h3 className="text-sm font-medium text-blue-900 mb-2">Twilio Webhook URL</h3>
-            <p className="text-sm text-blue-700 mb-2">
-              Set this URL in your Twilio phone number configuration under "A call comes in"
+          {/* Webhook URL — stacked */}
+          <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Twilio Webhook URL</h3>
+            <p className="text-xs text-gray-500 mb-3">
+              Set this in your Twilio phone number under "A call comes in"
             </p>
-            <div className="flex space-x-2">
-              <input
-                type="text"
-                value={webhookUrl}
-                readOnly
-                className="flex-1 px-4 py-2 bg-white border border-blue-300 rounded-lg text-sm"
-              />
-              <button
-                onClick={() => copyToClipboard(webhookUrl)}
-                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 text-sm"
-              >
-                Copy
-              </button>
-            </div>
+            <input
+              type="text"
+              value={webhookUrl}
+              readOnly
+              className="w-full text-sm font-mono px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 truncate focus:outline-none"
+            />
+            <button
+              onClick={copyWebhook}
+              className="w-full mt-2 py-3 flex items-center justify-center gap-2 rounded-xl border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            >
+              <Clipboard className="w-4 h-4" />
+              {copied ? 'Copied!' : 'Copy Webhook URL'}
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/CallLogs.jsx
+++ b/frontend/src/pages/CallLogs.jsx
@@ -1,12 +1,36 @@
 import { useState, useEffect } from 'react';
-import { Search, Download, ListFilter as Filter } from 'lucide-react';
+import { Search, Download, Copy } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+
+const STATUS_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Done', value: 'completed' },
+  { label: 'Live', value: 'in-progress' },
+  { label: 'Failed', value: 'failed' },
+  { label: 'Init', value: 'initiated' },
+];
+
+const statusColors = {
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  'in-progress': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  initiated: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+};
+
+const statusDot = {
+  completed: 'bg-green-500',
+  'in-progress': 'bg-blue-500',
+  failed: 'bg-red-500',
+  initiated: 'bg-gray-400',
+};
 
 const CallLogs = () => {
   const [logs, setLogs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
+  const [expandedId, setExpandedId] = useState(null);
+  const [copiedSid, setCopiedSid] = useState(null);
 
   useEffect(() => {
     fetchLogs();
@@ -17,10 +41,7 @@ const CallLogs = () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user) {
-      setLoading(false);
-      return;
-    }
+    if (!user) { setLoading(false); return; }
 
     const { data } = await supabase
       .from('call_logs')
@@ -37,9 +58,7 @@ const CallLogs = () => {
       log.from_number?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       log.to_number?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       log.call_sid?.toLowerCase().includes(searchTerm.toLowerCase());
-
     const matchesStatus = statusFilter === 'all' || log.status === statusFilter;
-
     return matchesSearch && matchesStatus;
   });
 
@@ -53,139 +72,124 @@ const CallLogs = () => {
       log.status,
       log.call_sid || 'N/A',
     ]);
-
-    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');
-
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
+    const csv = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+    const url = window.URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
     const a = document.createElement('a');
     a.href = url;
     a.download = `call-logs-${new Date().toISOString().split('T')[0]}.csv`;
     a.click();
   };
 
-  const getStatusColor = (status) => {
-    switch (status?.toLowerCase()) {
-      case 'completed':
-        return 'bg-green-100 text-green-800';
-      case 'in-progress':
-        return 'bg-blue-100 text-blue-800';
-      case 'failed':
-        return 'bg-red-100 text-red-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
+  const copySid = (sid) => {
+    navigator.clipboard.writeText(sid);
+    setCopiedSid(sid);
+    setTimeout(() => setCopiedSid(null), 2000);
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Call Logs</h1>
-          <p className="mt-1 text-sm text-gray-500">View and manage your call history</p>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">Call Logs</h1>
+          <p className="mt-0.5 text-sm text-gray-500">View and manage your call history</p>
         </div>
         <button
           onClick={exportToCSV}
-          className="flex items-center space-x-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+          className="flex items-center gap-2 px-4 py-2.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-colors"
         >
           <Download className="w-4 h-4" />
-          <span>Export CSV</span>
+          <span className="hidden sm:inline">Export CSV</span>
         </button>
       </div>
 
-      {/* Filters */}
-      <div className="bg-white rounded-lg shadow p-4">
-        <div className="flex flex-col md:flex-row gap-4">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-            <input
-              type="text"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              placeholder="Search by phone number or Call SID..."
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-            />
-          </div>
-          <div className="relative">
-            <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-            <select
-              value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
-              className="pl-10 pr-8 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent appearance-none bg-white"
-            >
-              <option value="all">All Status</option>
-              <option value="completed">Completed</option>
-              <option value="in-progress">In Progress</option>
-              <option value="failed">Failed</option>
-              <option value="initiated">Initiated</option>
-            </select>
-          </div>
-        </div>
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search numbers or Call SID…"
+          className="w-full pl-11 pr-4 py-3 text-base border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        />
       </div>
 
-      {/* Table */}
-      <div className="bg-white rounded-lg shadow overflow-hidden">
+      {/* Filter chips */}
+      <div className="flex gap-2 overflow-x-auto pb-1 -mx-4 px-4 scrollbar-none">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setStatusFilter(f.value)}
+            className={`flex-shrink-0 px-4 py-2 text-sm font-medium rounded-full border transition-colors ${
+              statusFilter === f.value
+                ? 'bg-primary-600 text-white border-primary-600'
+                : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-sm text-gray-500">{filteredLogs.length} call{filteredLogs.length !== 1 ? 's' : ''} found</p>
+
+      {/* Desktop table */}
+      <div className="hidden lg:block bg-white dark:bg-gray-800 rounded-xl shadow overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-700/50">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date & Time
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  From
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  To
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Duration
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Call SID
-                </th>
+                {['Date & Time', 'From', 'To', 'Duration', 'Status', 'Call SID'].map((h) => (
+                  <th
+                    key={h}
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
               {loading ? (
                 <tr>
-                  <td colSpan="6" className="px-6 py-8 text-center text-sm text-gray-500">
-                    Loading...
-                  </td>
+                  <td colSpan="6" className="px-6 py-8 text-center text-sm text-gray-500">Loading…</td>
                 </tr>
               ) : filteredLogs.length === 0 ? (
                 <tr>
-                  <td colSpan="6" className="px-6 py-8 text-center text-sm text-gray-500">
-                    No call logs found
-                  </td>
+                  <td colSpan="6" className="px-6 py-8 text-center text-sm text-gray-500">No call logs found</td>
                 </tr>
               ) : (
                 filteredLogs.map((log) => (
-                  <tr key={log.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/30">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {new Date(log.created_at).toLocaleString()}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {log.from_number || 'Unknown'}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {log.to_number || 'Unknown'}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {log.duration ? `${log.duration}s` : 'N/A'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusColor(log.status)}`}
-                      >
+                      <span className={`px-2 py-0.5 text-xs font-semibold rounded-full ${statusColors[log.status] ?? 'bg-gray-100 text-gray-800'}`}>
                         {log.status || 'unknown'}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">
-                      {log.call_sid ? log.call_sid.substring(0, 20) + '...' : 'N/A'}
+                      <button
+                        onClick={() => copySid(log.call_sid)}
+                        className="flex items-center gap-1 hover:text-primary-600 transition-colors"
+                        title="Copy SID"
+                      >
+                        <span>{log.call_sid ? log.call_sid.substring(0, 20) + '…' : 'N/A'}</span>
+                        {log.call_sid && <Copy className="w-3.5 h-3.5 flex-shrink-0" />}
+                      </button>
+                      {copiedSid === log.call_sid && (
+                        <span className="text-xs text-green-600">Copied!</span>
+                      )}
                     </td>
                   </tr>
                 ))
@@ -195,34 +199,90 @@ const CallLogs = () => {
         </div>
       </div>
 
-      {/* Stats */}
+      {/* Mobile card list */}
+      <ul className="lg:hidden space-y-3">
+        {loading ? (
+          <li className="text-center py-8 text-sm text-gray-500">Loading…</li>
+        ) : filteredLogs.length === 0 ? (
+          <li className="text-center py-8 text-sm text-gray-500">No call logs found</li>
+        ) : (
+          filteredLogs.map((log) => (
+            <li
+              key={log.id}
+              className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4 space-y-2"
+            >
+              {/* Row 1: status dot + from + badge */}
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${statusDot[log.status] ?? 'bg-gray-400'}`} />
+                <span className="flex-1 text-sm font-medium text-gray-900 dark:text-white truncate">
+                  {log.from_number || 'Unknown'}
+                </span>
+                <span className={`flex-shrink-0 px-2 py-0.5 text-xs font-semibold rounded-full ${statusColors[log.status] ?? 'bg-gray-100 text-gray-800'}`}>
+                  {log.status || 'unknown'}
+                </span>
+              </div>
+
+              {/* Row 2: to number */}
+              {log.to_number && (
+                <p className="text-xs text-gray-500 pl-4">→ {log.to_number}</p>
+              )}
+
+              {/* Row 3: duration · time */}
+              <p className="text-xs text-gray-500 pl-4">
+                {log.duration ? `${log.duration}s` : 'N/A'} &middot; {new Date(log.created_at).toLocaleString()}
+              </p>
+
+              {/* Row 4: SID + copy */}
+              {log.call_sid && (
+                <button
+                  onClick={() =>
+                    expandedId === log.id
+                      ? setExpandedId(null)
+                      : setExpandedId(log.id)
+                  }
+                  className="pl-4 text-xs text-gray-400 dark:text-gray-500 hover:text-primary-600 transition-colors text-left"
+                >
+                  {expandedId === log.id ? log.call_sid : log.call_sid.substring(0, 20) + '…'}
+                </button>
+              )}
+              {expandedId === log.id && log.call_sid && (
+                <button
+                  onClick={() => copySid(log.call_sid)}
+                  className="flex items-center gap-1.5 text-xs text-primary-600 pl-4"
+                >
+                  <Copy className="w-3.5 h-3.5" />
+                  {copiedSid === log.call_sid ? 'Copied!' : 'Copy SID'}
+                </button>
+              )}
+            </li>
+          ))
+        )}
+      </ul>
+
+      {/* Statistics */}
       {filteredLogs.length > 0 && (
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-4">Statistics</h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-4">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Statistics</h3>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <div>
-              <p className="text-2xl font-bold text-gray-900">{filteredLogs.length}</p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{filteredLogs.length}</p>
               <p className="text-sm text-gray-500">Total Calls</p>
             </div>
             <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {Math.round(
-                  filteredLogs.reduce((sum, log) => sum + (log.duration || 0), 0) /
-                    filteredLogs.length
-                )}
-                s
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {Math.round(filteredLogs.reduce((s, l) => s + (l.duration || 0), 0) / filteredLogs.length)}s
               </p>
               <p className="text-sm text-gray-500">Avg Duration</p>
             </div>
             <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {filteredLogs.filter((log) => log.status === 'completed').length}
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {filteredLogs.filter((l) => l.status === 'completed').length}
               </p>
               <p className="text-sm text-gray-500">Completed</p>
             </div>
             <div>
-              <p className="text-2xl font-bold text-gray-900">
-                {filteredLogs.filter((log) => log.status === 'failed').length}
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {filteredLogs.filter((l) => l.status === 'failed').length}
               </p>
               <p className="text-sm text-gray-500">Failed</p>
             </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,6 +2,18 @@ import { useState, useEffect } from 'react';
 import { Phone, Clock, DollarSign, Activity } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 
+const statusColors = {
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  'in-progress': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+const statusDot = {
+  completed: 'bg-green-500',
+  'in-progress': 'bg-blue-500',
+  failed: 'bg-red-500',
+};
+
 const Dashboard = () => {
   const [stats, setStats] = useState({
     totalCalls: 0,
@@ -46,20 +58,8 @@ const Dashboard = () => {
   };
 
   const statCards = [
-    {
-      name: 'Total Calls',
-      value: stats.totalCalls,
-      icon: Phone,
-      color: 'bg-blue-500',
-      change: '+12%',
-    },
-    {
-      name: 'Avg Duration',
-      value: `${stats.avgDuration}s`,
-      icon: Clock,
-      color: 'bg-green-500',
-      change: '+4.5%',
-    },
+    { name: 'Total Calls', value: stats.totalCalls, icon: Phone, color: 'bg-blue-500', change: '+12%' },
+    { name: 'Avg Duration', value: `${stats.avgDuration}s`, icon: Clock, color: 'bg-green-500', change: '+4.5%' },
     {
       name: 'Status',
       value: stats.activeConfig ? 'Active' : 'Inactive',
@@ -67,36 +67,30 @@ const Dashboard = () => {
       color: 'bg-yellow-500',
       change: stats.activeConfig ? 'Running' : 'Stopped',
     },
-    {
-      name: 'This Month',
-      value: '$0.00',
-      icon: DollarSign,
-      color: 'bg-purple-500',
-      change: 'Est. cost',
-    },
+    { name: 'This Month', value: '$0.00', icon: DollarSign, color: 'bg-purple-500', change: 'Est. cost' },
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <header role="region" aria-labelledby="dashboard-heading">
-        <h1 id="dashboard-heading" className="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <h1 id="dashboard-heading" className="text-2xl font-bold text-gray-900 dark:text-white">Dashboard</h1>
         <p className="mt-1 text-sm text-gray-500">Overview of your AI voice assistant</p>
       </header>
 
-      {/* Stats Grid */}
-      <section role="region" aria-label="Statistics Overview" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {/* Stats Grid — 2 cols on mobile, 4 on desktop */}
+      <section role="region" aria-label="Statistics Overview" className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {statCards.map((stat) => {
           const Icon = stat.icon;
           return (
-            <div key={stat.name} className="bg-white rounded-lg shadow p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-gray-600">{stat.name}</p>
-                  <p className="mt-2 text-3xl font-semibold text-gray-900">{stat.value}</p>
-                  <p className="mt-2 text-xs text-gray-500">{stat.change}</p>
+            <div key={stat.name} className="bg-white dark:bg-gray-800 rounded-xl shadow p-4">
+              <div className="flex items-start justify-between">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-gray-500 dark:text-gray-400 truncate">{stat.name}</p>
+                  <p className="mt-1.5 text-2xl font-semibold text-gray-900 dark:text-white">{stat.value}</p>
+                  <p className="mt-1 text-xs text-gray-500">{stat.change}</p>
                 </div>
-                <div className={`${stat.color} p-3 rounded-lg`}>
-                  <Icon className="w-6 h-6 text-white" />
+                <div className={`${stat.color} p-2.5 rounded-lg flex-shrink-0 ml-2`}>
+                  <Icon className="w-5 h-5 text-white" />
                 </div>
               </div>
             </div>
@@ -106,54 +100,58 @@ const Dashboard = () => {
 
       {/* Active Configuration */}
       {stats.activeConfig && (
-        <section role="region" aria-labelledby="active-config-heading" className="bg-white rounded-lg shadow p-6">
-          <h2 id="active-config-heading" className="text-lg font-semibold text-gray-900 mb-4">Active Configuration</h2>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <p className="text-sm text-gray-600">Name</p>
-              <p className="font-medium">{stats.activeConfig.name}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-600">Voice</p>
-              <p className="font-medium capitalize">{stats.activeConfig.voice}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-600">Temperature</p>
-              <p className="font-medium">{stats.activeConfig.temperature}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-600">Greeting</p>
-              <p className="font-medium">{stats.activeConfig.enable_greeting ? 'Enabled' : 'Disabled'}</p>
-            </div>
-          </div>
+        <section
+          role="region"
+          aria-labelledby="active-config-heading"
+          className="bg-white dark:bg-gray-800 rounded-xl shadow p-4"
+        >
+          <h2 id="active-config-heading" className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+            Active Configuration
+          </h2>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2.5">
+            {[
+              ['Name', stats.activeConfig.name],
+              ['Voice', stats.activeConfig.voice],
+              ['Temperature', stats.activeConfig.temperature],
+              ['Greeting', stats.activeConfig.enable_greeting ? 'Enabled' : 'Disabled'],
+            ].map(([label, value]) => (
+              <div key={label} className="contents">
+                <dt className="text-sm text-gray-500 dark:text-gray-400 self-center">{label}</dt>
+                <dd className="text-sm font-medium text-gray-900 dark:text-white capitalize truncate self-center">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
         </section>
       )}
 
       {/* Recent Calls */}
-      <section role="region" aria-labelledby="recent-calls-heading" className="bg-white rounded-lg shadow">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h2 id="recent-calls-heading" className="text-lg font-semibold text-gray-900">Recent Calls</h2>
+      <section role="region" aria-labelledby="recent-calls-heading" className="bg-white dark:bg-gray-800 rounded-xl shadow">
+        <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h2 id="recent-calls-heading" className="text-base font-semibold text-gray-900 dark:text-white">
+            Recent Calls
+          </h2>
         </div>
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200" role="table" aria-label="Recent Calls Table">
+
+        {/* Desktop table */}
+        <div className="hidden lg:block overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700" role="table" aria-label="Recent Calls Table">
             <caption className="sr-only">Recent calls list showing from, duration, status and time</caption>
-            <thead className="bg-gray-50">
+            <thead className="bg-gray-50 dark:bg-gray-700/50">
               <tr>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  From
-                </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Duration
-                </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Time
-                </th>
+                {['From', 'Duration', 'Status', 'Time'].map((h) => (
+                  <th
+                    key={h}
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
               {stats.recentCalls.length === 0 ? (
                 <tr>
                   <td colSpan="4" className="px-6 py-4 text-center text-sm text-gray-500">
@@ -163,14 +161,14 @@ const Dashboard = () => {
               ) : (
                 stats.recentCalls.map((call) => (
                   <tr key={call.id}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {call.from_number || 'Unknown'}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                       {call.duration}s
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                      <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[call.status] ?? 'bg-gray-100 text-gray-800'}`}>
                         {call.status}
                       </span>
                     </td>
@@ -183,6 +181,34 @@ const Dashboard = () => {
             </tbody>
           </table>
         </div>
+
+        {/* Mobile card list */}
+        <ul className="lg:hidden divide-y divide-gray-100 dark:divide-gray-700">
+          {stats.recentCalls.length === 0 ? (
+            <li className="px-4 py-6 text-center text-sm text-gray-500">No calls yet</li>
+          ) : (
+            stats.recentCalls.map((call) => (
+              <li key={call.id} className="flex items-center gap-3 px-4 py-3">
+                <span
+                  className={`w-2 h-2 rounded-full flex-shrink-0 ${statusDot[call.status] ?? 'bg-gray-400'}`}
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    {call.from_number || 'Unknown'}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {call.duration}s &middot; {new Date(call.created_at).toLocaleString()}
+                  </p>
+                </div>
+                <span
+                  className={`flex-shrink-0 px-2 py-0.5 text-xs font-semibold rounded-full ${statusColors[call.status] ?? 'bg-gray-100 text-gray-800'}`}
+                >
+                  {call.status}
+                </span>
+              </li>
+            ))
+          )}
+        </ul>
       </section>
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Eye, EyeOff, Phone } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [mode, setMode] = useState('password'); // 'password' | 'magic'
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -32,53 +34,94 @@ export default function Login() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-20 p-6 bg-slate-800 rounded-lg">
-      <h1 className="text-2xl mb-6 font-semibold">Sign in</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1 text-sm text-slate-300">Email</label>
-          <input
-            type="email"
-            required
-            className="w-full px-3 py-2 rounded bg-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
-          />
+    <div className="min-h-screen flex items-center justify-center px-4 bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-md">
+        {/* Branding */}
+        <div className="flex flex-col items-center mb-8">
+          <div className="w-14 h-14 bg-gradient-to-br from-primary-500 to-primary-600 rounded-2xl flex items-center justify-center shadow-lg mb-3">
+            <Phone className="w-7 h-7 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">AI Assistant</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Sign in to continue</p>
         </div>
 
-        {mode === 'password' && (
-          <div>
-            <label className="block mb-1 text-sm text-slate-300">Password</label>
-            <input
-              type="password"
-              required
-              className="w-full px-3 py-2 rounded bg-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-            />
-          </div>
-        )}
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Email
+              </label>
+              <input
+                type="email"
+                required
+                className="w-full px-4 py-3 text-base rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+              />
+            </div>
 
-        {error && <p className="text-red-400 text-sm">{error}</p>}
-        {message && <p className="text-green-400 text-sm">{message}</p>}
+            {mode === 'password' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                  Password
+                </label>
+                <div className="relative">
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    required
+                    className="w-full px-4 py-3 text-base pr-12 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  >
+                    {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                  </button>
+                </div>
+              </div>
+            )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 rounded font-medium transition-colors"
-        >
-          {loading ? 'Please wait…' : mode === 'magic' ? 'Send magic link' : 'Sign in'}
-        </button>
-      </form>
+            {error && (
+              <div className="rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+                {error}
+              </div>
+            )}
+            {message && (
+              <div className="rounded-lg bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 px-4 py-3 text-sm text-green-700 dark:text-green-400">
+                {message}
+              </div>
+            )}
 
-      <button
-        className="mt-4 text-sm text-slate-400 hover:text-slate-200 underline"
-        onClick={() => { setMode(mode === 'password' ? 'magic' : 'password'); setError(''); setMessage(''); }}
-      >
-        {mode === 'password' ? 'Sign in with magic link instead' : 'Sign in with password instead'}
-      </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3 bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-xl font-medium text-white transition-colors"
+            >
+              {loading ? 'Please wait…' : mode === 'magic' ? 'Send magic link' : 'Sign in'}
+            </button>
+          </form>
+
+          <button
+            type="button"
+            className="w-full py-3 border border-gray-300 dark:border-gray-600 rounded-xl text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            onClick={() => {
+              setMode(mode === 'password' ? 'magic' : 'password');
+              setError('');
+              setMessage('');
+            }}
+          >
+            {mode === 'password' ? 'Sign in with magic link instead' : 'Sign in with password instead'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Mobile-first UI redesign** across all frontend pages — designed from 375px up, fully responsive to desktop
- **Bottom tab bar navigation** on mobile (replaces hamburger + sidebar), active route detection via `useLocation`
- **Card lists replacing tables** on mobile with `hidden lg:block` / `lg:hidden` pattern
- **Safe-area-aware positioning** for FAB and bottom nav using `env(safe-area-inset-bottom)`
- **44px+ touch targets** throughout: toggle switches, filter chips, enlarged modal close button (40px)
- **No iOS zoom** on inputs — all inputs use `py-3 text-base` (16px font)
- **MCP tool calling** integration so the AI can execute real actions during calls
- **Real auth** — PrivateRoute and Login now use Supabase; all API routes protected
- **OAuth system** with 39 passing tests (signup, login, refresh, logout, /me)
- **CLAUDE.md** comprehensive codebase documentation

## Key changes per file

| File | Change |
|------|--------|
| `frontend/index.html` | `viewport-fit=cover` |
| `frontend/src/index.css` | `.scrollbar-none` utility |
| `frontend/src/components/Layout.jsx` | Bottom tab bar, slim header, `useLocation` active routes |
| `frontend/src/components/FAB.jsx` | Safe-area bottom position |
| `frontend/src/components/Modal.jsx` | Bottom sheet on mobile, drag handle, 40px close button |
| `frontend/src/pages/Login.jsx` | Centered viewport, 16px inputs, full-width mode toggle |
| `frontend/src/pages/Dashboard.jsx` | 2-col stats, definition list, call cards on mobile |
| `frontend/src/pages/AIConfig.jsx` | Chip carousel, 3-col voice grid, disclosure textarea, toggle switches |
| `frontend/src/pages/APIKeys.jsx` | Stacked show/hide, full-width webhook copy |
| `frontend/src/pages/CallLogs.jsx` | Filter chips, card list, expand-in-place SID copy |

## Test plan

- [ ] Open at 375px (iPhone SE) in Chrome DevTools — bottom nav visible, no horizontal overflow
- [ ] Open at 390px (iPhone 14) — verify safe-area padding works
- [ ] Open at ≥1024px — bottom nav hidden, sidebar visible
- [ ] Tap inputs on iOS — no zoom (font-size 16px+)
- [ ] Swipe persona chip carousel — no overflow
- [ ] Call Logs: filter chips work, card list shows on mobile, table on desktop
- [ ] Modal opens as bottom sheet on mobile, centered dialog on desktop
- [ ] FAB sits above bottom nav, not hidden by it

https://claude.ai/code/session_01TMzwxFYUYt3fgp7qj8knAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMzwxFYUYt3fgp7qj8knAE)_